### PR TITLE
trident-launcher: pass -debug onto ephemeral container

### DIFF
--- a/launcher/kube_client.go
+++ b/launcher/kube_client.go
@@ -236,6 +236,9 @@ func (k *KubeClient) StartInMemoryTrident() (string, error) {
 			},
 		},
 	}
+	if *debug {
+		podToCreate.Spec.Containers[0].Args = append(podToCreate.Spec.Containers[0].Args, "-debug")
+	}
 	log.Debug("Creating Trident.")
 	_, err := k.clientset.Core().Pods(k.namespace).Create(podToCreate)
 	if err != nil {


### PR DESCRIPTION
This adds the debug option to the pod spec for trident-ephemeral if trident-launcher has been started with 
`-debug` as well. This makes it much easier to find problems with the initial backend configuration.