### PR TITLE
Add NetApp HCI to list of Element-based products

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ combination of NetApp’s
 [ONTAP](https://www.netapp.com/us/products/data-management-software/ontap.aspx)
 (AFF/FAS/Select/Cloud),
 [Element](https://www.netapp.com/us/products/data-management-software/element-os.aspx)
-(SolidFire), or
+(HCI/SolidFire), or
 [SANtricity](https://www.netapp.com/us/products/data-management-software/santricity-os.aspx)
 (E/EF-Series) data management platforms.
 


### PR DESCRIPTION
To make it clear NetApp HCI runs Element (OS).

We should use "NetApp HCI", but all products use the short name so I didn't do that. Feel free to edit if necessary.