### PR TITLE
Minor update for K8S install command

### DIFF
--- a/docs/reference/simple-kubernetes.rst
+++ b/docs/reference/simple-kubernetes.rst
@@ -47,7 +47,7 @@ Install the appropriate version of kubeadm, kubectl and kubelet
   deb http://apt.kubernetes.io/ kubernetes-xenial main
   EOF
   apt-get update
-  apt-get install -y kubeadm=1.8\* kubectl=1.8\* kubelet=1.8\*
+  apt-get install -y kubeadm=1.8\* kubectl=1.8\* kubelet=1.8\* kubernetes-cni=0.5\*
 
 Configure the host
 ==================


### PR DESCRIPTION
... is required due to a newer kubernetes-cni version being available, but kube*1.8 not being able to work with that version