### PR TITLE
docker: add open-iscsi pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update || true &&  \
 	kmod \
 	curl \
 	jq \
+	open-iscsi \
 	ca-certificates
 
 # for go binaries to work inside an alpine container


### PR DESCRIPTION
When running atop a host running Kubernetes, we see the following warning:
```
time="2018-06-12T03:20:36Z" level=warning msg="Unable to detach volume, deleting anyway: exec: \"iscsiadm\": executable file not found in $PATH"                                                                                                                              
```
This pull request is to include the open-iscsi package which includes `iscsiadm` tool. This hasn't been tested, but I believe it should include it.