### PR TITLE
Allow to specify space-allocation option when using ontap_san backend

### DIFF
--- a/docs/kubernetes/concepts/objects.rst
+++ b/docs/kubernetes/concepts/objects.rst
@@ -76,6 +76,7 @@ trident.netapp.io/snapshotPolicy    snapshotPolicy    ontap-nas, ontap-nas-econo
 trident.netapp.io/snapshotDirectory snapshotDirectory ontap-nas, ontap-nas-economy
 trident.netapp.io/unixPermissions   unixPermissions   ontap-nas, ontap-nas-economy
 trident.netapp.io/blockSize         blockSize         solidfire-san
+trident.netapp.io/spaceAllocate     spaceAllocate     ontap-san
 =================================== ================= ======================================================
 
 The reclaim policy for the created PV can be determined by setting the

--- a/frontend/kubernetes/config.go
+++ b/frontend/kubernetes/config.go
@@ -27,6 +27,7 @@ const (
 	AnnPrefix          = config.OrchestratorName + ".netapp.io"
 	AnnReclaimPolicy   = AnnPrefix + "/reclaimPolicy"
 	AnnProtocol        = AnnPrefix + "/protocol"
+	AnnSpaceAllocate   = AnnPrefix + "/spaceAllocate"
 	AnnSpaceReserve    = AnnPrefix + "/spaceReserve"
 	AnnSnapshotPolicy  = AnnPrefix + "/snapshotPolicy"
 	AnnSnapshotDir     = AnnPrefix + "/snapshotDirectory"

--- a/frontend/kubernetes/volumes.go
+++ b/frontend/kubernetes/volumes.go
@@ -89,6 +89,7 @@ func getVolumeConfig(
 		Name:              name,
 		Size:              fmt.Sprintf("%d", size.Value()),
 		Protocol:          config.Protocol(getAnnotation(annotations, AnnProtocol)),
+		SpaceAllocate:     getAnnotation(annotations, AnnSpaceAllocate),
 		SnapshotPolicy:    getAnnotation(annotations, AnnSnapshotPolicy),
 		ExportPolicy:      getAnnotation(annotations, AnnExportPolicy),
 		SnapshotDir:       getAnnotation(annotations, AnnSnapshotDir),

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -19,6 +19,7 @@ type VolumeConfig struct {
 	Size                      string                 `json:"size"`
 	Protocol                  config.Protocol        `json:"protocol"`
 	SpaceReserve              string                 `json:"spaceReserve"`
+	SpaceAllocate             string                 `json:"spaceAllocate"`
 	SecurityStyle             string                 `json:"securityStyle"`
 	SnapshotPolicy            string                 `json:"snapshotPolicy,omitempty"`
 	ExportPolicy              string                 `json:"exportPolicy,omitempty"`

--- a/storage_drivers/ontap/api/ontap.go
+++ b/storage_drivers/ontap/api/ontap.go
@@ -265,12 +265,13 @@ func (d Client) IgroupList() (response azgo.IgroupGetIterResponse, err error) {
 
 // LunCreate creates a lun with the specified attributes
 // equivalent to filer::> lun create -vserver iscsi_vs -path /vol/v/lun1 -size 1g -ostype linux -space-reserve disabled
-func (d Client) LunCreate(lunPath string, sizeInBytes int, osType string, spaceReserved bool) (response azgo.LunCreateBySizeResponse, err error) {
+func (d Client) LunCreate(lunPath string, sizeInBytes int, osType string, spaceReserved bool, spaceAllocated bool) (response azgo.LunCreateBySizeResponse, err error) {
 	response, err = azgo.NewLunCreateBySizeRequest().
 		SetPath(lunPath).
 		SetSize(sizeInBytes).
 		SetOstype(osType).
 		SetSpaceReservationEnabled(spaceReserved).
+		SetSpaceAllocationEnabled(spaceAllocated).
 		ExecuteUsing(d.zr)
 	return
 }

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -314,7 +314,10 @@ func ValidateDataLIFs(config *drivers.OntapStorageDriverConfig, dataLIFs []strin
 	return nil
 }
 
-const DefaultSpaceAllocate = "false"
+// Enable space-allocation by default. If not enabled, Data ONTAP takes the LUNs offline
+// when they're seen as full.
+// see: https://github.com/NetApp/trident/issues/135
+const DefaultSpaceAllocate = "true"
 const DefaultSpaceReserve = "none"
 const DefaultSnapshotPolicy = "none"
 const DefaultUnixPermissions = "---rwxrwxrwx"

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -1000,6 +1000,9 @@ func getVolumeOptsCommon(
 	if volConfig.ExportPolicy != "" {
 		opts["exportPolicy"] = volConfig.ExportPolicy
 	}
+	if volConfig.SpaceAllocate != "" {
+		opts["spaceAllocate"] = volConfig.SpaceAllocate
+	}
 	if volConfig.SpaceReserve != "" {
 		opts["spaceReserve"] = volConfig.SpaceReserve
 	}

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -314,6 +314,7 @@ func ValidateDataLIFs(config *drivers.OntapStorageDriverConfig, dataLIFs []strin
 	return nil
 }
 
+const DefaultSpaceAllocate = "false"
 const DefaultSpaceReserve = "none"
 const DefaultSnapshotPolicy = "none"
 const DefaultUnixPermissions = "---rwxrwxrwx"
@@ -347,6 +348,10 @@ func PopulateConfigurationDefaults(config *drivers.OntapStorageDriverConfig) err
 	if config.StoragePrefix == nil {
 		prefix := drivers.GetDefaultStoragePrefix(config.DriverContext)
 		config.StoragePrefix = &prefix
+	}
+
+	if config.SpaceAllocate == "" {
+		config.SpaceAllocate = DefaultSpaceAllocate
 	}
 
 	if config.SpaceReserve == "" {
@@ -396,6 +401,7 @@ func PopulateConfigurationDefaults(config *drivers.OntapStorageDriverConfig) err
 
 	log.WithFields(log.Fields{
 		"StoragePrefix":   *config.StoragePrefix,
+		"SpaceAllocate":   config.SpaceAllocate,
 		"SpaceReserve":    config.SpaceReserve,
 		"SnapshotPolicy":  config.SnapshotPolicy,
 		"UnixPermissions": config.UnixPermissions,

--- a/storage_drivers/ontap/ontap_san.go
+++ b/storage_drivers/ontap/ontap_san.go
@@ -200,6 +200,7 @@ func (d *SANStorageDriver) Create(name string, sizeBytes uint64, opts map[string
 	// Get options with default fallback values
 	// see also: ontap_common.go#PopulateConfigurationDefaults
 	size := strconv.FormatUint(sizeBytes, 10)
+	spaceAllocate, _ := strconv.ParseBool(utils.GetV(opts, "spaceAllocate", d.Config.SpaceAllocate))
 	spaceReserve := utils.GetV(opts, "spaceReserve", d.Config.SpaceReserve)
 	snapshotPolicy := utils.GetV(opts, "snapshotPolicy", d.Config.SnapshotPolicy)
 	unixPermissions := utils.GetV(opts, "unixPermissions", d.Config.UnixPermissions)
@@ -226,6 +227,7 @@ func (d *SANStorageDriver) Create(name string, sizeBytes uint64, opts map[string
 	log.WithFields(log.Fields{
 		"name":            name,
 		"size":            size,
+		"spaceAllocate":   spaceAllocate,
 		"spaceReserve":    spaceReserve,
 		"snapshotPolicy":  snapshotPolicy,
 		"unixPermissions": unixPermissions,
@@ -257,7 +259,7 @@ func (d *SANStorageDriver) Create(name string, sizeBytes uint64, opts map[string
 	osType := "linux"
 
 	// Create the LUN
-	lunCreateResponse, err := d.API.LunCreate(lunPath, int(sizeBytes), osType, false)
+	lunCreateResponse, err := d.API.LunCreate(lunPath, int(sizeBytes), osType, false, spaceAllocate)
 	if err = api.GetError(lunCreateResponse, err); err != nil {
 		return fmt.Errorf("error creating LUN: %v", err)
 	}

--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -82,6 +82,7 @@ type OntapStorageDriverConfig struct {
 }
 
 type OntapStorageDriverConfigDefaults struct {
+	SpaceAllocate   string `json:"spaceAllocate"`
 	SpaceReserve    string `json:"spaceReserve"`
 	SnapshotPolicy  string `json:"snapshotPolicy"`
 	UnixPermissions string `json:"unixPermissions"`

--- a/trident-installer/sample-input/pvc-full.yaml
+++ b/trident-installer/sample-input/pvc-full.yaml
@@ -10,6 +10,7 @@ metadata:
     trident.netapp.io/protocol: "file"
     trident.netapp.io/snapshotDirectory: "false"
     trident.netapp.io/unixPermissions: "---rwxrwxrwx"
+    trident.netapp.io/spaceAllocate: "false"
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Further details in: https://github.com/NetApp/trident/issues/135

In term of implementation, the `storage_drivers/ontap/api/azgo` library was already supporting the option, so I just passed it down at the `ontap_san` driver level.

It also recognize the `trident.netapp.io/spaceAllocate` PVC's annotation in order to allow to modify that setting on a case per case basis.