### PR TITLE
WIP: Allow to customize percent-snapshot-reserve option for ontap_san backend

### DIFF
--- a/docs/docker/install/ndvp_ontap_config.rst
+++ b/docs/docker/install/ndvp_ontap_config.rst
@@ -11,7 +11,7 @@ Below are the ONTAP CLI comands to create a dedicated user for Trident with spec
 
   # create a new Trident role
   security login role create -vserver [VSERVER] -role trident_role -cmddirname DEFAULT -access none
-  
+
   # grant common Trident permissions
   security login role create -vserver [VSERVER] -role trident_role -cmddirname "event generate-autosupport-log" -access all
   security login role create -vserver [VSERVER] -role trident_role -cmddirname "network interface" -access readonly
@@ -76,27 +76,29 @@ For the ontap-san driver, an additional top level option is available to specify
 
 Also, when using ONTAP, these default option settings are available to avoid having to specify them on every volume create.
 
-+-----------------------+--------------------------------------------------------------------------+------------+
-| Defaults Option       | Description                                                              | Example    |
-+=======================+==========================================================================+============+
-| ``spaceReserve``      | Space reservation mode; "none" (thin provisioned) or "volume" (thick)    | none       |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``snapshotPolicy``    | Snapshot policy to use, default is "none"                                | none       |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``splitOnClone``      | Split a clone from its parent upon creation, defaults to "false"         | false      |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``encryption``        | Enable NetApp Volume Encryption, defaults to "false"                     | true       |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``unixPermissions``   | NAS option for provisioned NFS volumes, defaults to "777"                | 777        |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``snapshotDir``       | NAS option for access to the .snapshot directory, defaults to "false"    | false      |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``exportPolicy``      | NAS option for the NFS export policy to use, defaults to "default"       | default    |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``securityStyle``     | NAS option for access to the provisioned NFS volume, defaults to "unix"  | mixed      |
-+-----------------------+--------------------------------------------------------------------------+------------+
-| ``fileSystemType``    | SAN option to select the file system type, defaults to "ext4"            | xfs        |
-+-----------------------+--------------------------------------------------------------------------+------------+
++-------------------------------+--------------------------------------------------------------------------+------------+
+| Defaults Option               | Description                                                              | Example    |
++===============================+==========================================================================+============+
+| ``spaceReserve``              | Space reservation mode; "none" (thin provisioned) or "volume" (thick)    | none       |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``snapshotPolicy``            | Snapshot policy to use, default is "none"                                | none       |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``percentageSnapshotReserve`` | Percent of volume to reserve for snapshots, default is "none"            | none       |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``splitOnClone``              | Split a clone from its parent upon creation, defaults to "false"         | false      |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``encryption``                | Enable NetApp Volume Encryption, defaults to "false"                     | true       |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``unixPermissions``           | NAS option for provisioned NFS volumes, defaults to "777"                | 777        |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``snapshotDir``               | NAS option for access to the .snapshot directory, defaults to "false"    | false      |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``exportPolicy``              | NAS option for the NFS export policy to use, defaults to "default"       | default    |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``securityStyle``             | NAS option for access to the provisioned NFS volume, defaults to "unix"  | mixed      |
++-------------------------------+--------------------------------------------------------------------------+------------+
+| ``fileSystemType``            | SAN option to select the file system type, defaults to "ext4"            | xfs        |
++-------------------------------+--------------------------------------------------------------------------+------------+
 
 Scaling Options
 ---------------

--- a/docs/docker/use/backends/ontap_options.rst
+++ b/docs/docker/use/backends/ontap_options.rst
@@ -18,9 +18,10 @@ NFS has two additional options that aren't relevant when using iSCSI:
 * ``exportPolicy`` - sets the export policy to be used for the volume.  The default is ``default``.
 * ``securityStyle`` - sets the security style to be used for access to the volume.  The default is ``unix``. Valid values are ``unix`` and ``mixed``.
 
-iSCSI has an additional option that isn't relevant when using NFS:
+iSCSI has few additional options that aren't relevant when using NFS:
 
 * ``fileSystemType`` - sets the file system used to format iSCSI volumes.  The default is ``ext4``.  Valid values are ``ext3``, ``ext4``, and ``xfs``.
+* ``percentageSnapshotReserve`` - this will modify the percentage of space to reserve for snapshots on the volume. If nothing is set, it uses the SAN's default configuration.
 
 
 Using these options during the docker volume create operation is super simple, just provide the option and the value using the ``-o`` operator during the CLI operation.  These override any equivalent vales from the JSON configuration file.

--- a/storage_drivers/ontap/api/ontap.go
+++ b/storage_drivers/ontap/api/ontap.go
@@ -468,13 +468,14 @@ func (d Client) LunGetAll(pathPattern string) (response azgo.LunGetIterResponse,
 // VolumeCreate creates a volume with the specified options
 // equivalent to filer::> volume create -vserver iscsi_vs -volume v -aggregate aggr1 -size 1g -state online -type RW -policy default -unix-permissions ---rwxr-xr-x -space-guarantee none -snapshot-policy none -security-style unix -encrypt false
 func (d Client) VolumeCreate(name, aggregateName, size, spaceReserve, snapshotPolicy, unixPermissions,
-	exportPolicy, securityStyle string, encrypt *bool) (response azgo.VolumeCreateResponse, err error) {
+	exportPolicy, securityStyle string, encrypt *bool, percentageSnapshotReserve) (response azgo.VolumeCreateResponse, err error) {
 	request := azgo.NewVolumeCreateRequest().
 		SetVolume(name).
 		SetContainingAggrName(aggregateName).
 		SetSize(size).
 		SetSpaceReserve(spaceReserve).
 		SetSnapshotPolicy(snapshotPolicy).
+		SetPercentageSnapshotReserve(percentageSnapshotReserve).
 		SetUnixPermissions(unixPermissions).
 		SetExportPolicy(exportPolicy).
 		SetVolumeSecurityStyle(securityStyle)

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -316,6 +316,7 @@ func ValidateDataLIFs(config *drivers.OntapStorageDriverConfig, dataLIFs []strin
 
 const DefaultSpaceReserve = "none"
 const DefaultSnapshotPolicy = "none"
+const DefaultPercentageSnapshotReserve = "none"
 const DefaultUnixPermissions = "---rwxrwxrwx"
 const DefaultSnapshotDir = "false"
 const DefaultExportPolicy = "default"
@@ -355,6 +356,10 @@ func PopulateConfigurationDefaults(config *drivers.OntapStorageDriverConfig) err
 
 	if config.SnapshotPolicy == "" {
 		config.SnapshotPolicy = DefaultSnapshotPolicy
+	}
+
+	if config.PercentageSnapshotReserve == "" {
+		config.PercentageSnapshotReserve = DefaultPercentageSnapshotReserve
 	}
 
 	if config.UnixPermissions == "" {

--- a/storage_drivers/ontap/ontap_san.go
+++ b/storage_drivers/ontap/ontap_san.go
@@ -202,6 +202,7 @@ func (d *SANStorageDriver) Create(name string, sizeBytes uint64, opts map[string
 	size := strconv.FormatUint(sizeBytes, 10)
 	spaceReserve := utils.GetV(opts, "spaceReserve", d.Config.SpaceReserve)
 	snapshotPolicy := utils.GetV(opts, "snapshotPolicy", d.Config.SnapshotPolicy)
+	percentageSnapshotReserve := utils.GetV(opts, "percentageSnapshotReserve", d.Config.PercentageSnapshotReserve)
 	unixPermissions := utils.GetV(opts, "unixPermissions", d.Config.UnixPermissions)
 	snapshotDir := utils.GetV(opts, "snapshotDir", d.Config.SnapshotDir)
 	exportPolicy := utils.GetV(opts, "exportPolicy", d.Config.ExportPolicy)
@@ -224,22 +225,23 @@ func (d *SANStorageDriver) Create(name string, sizeBytes uint64, opts map[string
 	}
 
 	log.WithFields(log.Fields{
-		"name":            name,
-		"size":            size,
-		"spaceReserve":    spaceReserve,
-		"snapshotPolicy":  snapshotPolicy,
-		"unixPermissions": unixPermissions,
-		"snapshotDir":     snapshotDir,
-		"exportPolicy":    exportPolicy,
-		"aggregate":       aggregate,
-		"securityStyle":   securityStyle,
-		"encryption":      encryption,
+		"name":                      name,
+		"size":                      size,
+		"spaceReserve":              spaceReserve,
+		"snapshotPolicy":            snapshotPolicy,
+		"percentageSnapshotReserve": percentageSnapshotReserve,
+		"unixPermissions":           unixPermissions,
+		"snapshotDir":               snapshotDir,
+		"exportPolicy":              exportPolicy,
+		"aggregate":                 aggregate,
+		"securityStyle":             securityStyle,
+		"encryption":                encryption,
 	}).Debug("Creating Flexvol.")
 
 	// Create the volume
 	volCreateResponse, err := d.API.VolumeCreate(
 		name, aggregate, size, spaceReserve, snapshotPolicy,
-		unixPermissions, exportPolicy, securityStyle, encrypt)
+		unixPermissions, exportPolicy, securityStyle, encrypt, percentageSnapshotReserve)
 
 	if err = api.GetError(volCreateResponse, err); err != nil {
 		if zerr, ok := err.(api.ZapiError); ok {

--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -82,15 +82,16 @@ type OntapStorageDriverConfig struct {
 }
 
 type OntapStorageDriverConfigDefaults struct {
-	SpaceReserve    string `json:"spaceReserve"`
-	SnapshotPolicy  string `json:"snapshotPolicy"`
-	UnixPermissions string `json:"unixPermissions"`
-	SnapshotDir     string `json:"snapshotDir"`
-	ExportPolicy    string `json:"exportPolicy"`
-	SecurityStyle   string `json:"securityStyle"`
-	SplitOnClone    string `json:"splitOnClone"`
-	FileSystemType  string `json:"fileSystemType"`
-	Encryption      string `json:"encryption"`
+	SpaceReserve              string `json:"spaceReserve"`
+	SnapshotPolicy            string `json:"snapshotPolicy"`
+	PercentageSnapshotReserve string `json:"percentageSnapshotReserve"`
+	UnixPermissions           string `json:"unixPermissions"`
+	SnapshotDir               string `json:"snapshotDir"`
+	ExportPolicy              string `json:"exportPolicy"`
+	SecurityStyle             string `json:"securityStyle"`
+	SplitOnClone              string `json:"splitOnClone"`
+	FileSystemType            string `json:"fileSystemType"`
+	Encryption                string `json:"encryption"`
 	CommonStorageDriverConfigDefaults
 }
 


### PR DESCRIPTION
See details in: https://github.com/NetApp/trident/issues/43

The idea is to provide a way to customize the percentage of space reserved for snapshots when creating a new volume.

I might need some help/guidance to test it properly.