### PR TITLE
Add failure domain support

### DIFF
--- a/cli/api/types.go
+++ b/cli/api/types.go
@@ -15,6 +15,7 @@ type Backend struct {
 		StorageDriverName string   `json:"storageDriverName"`
 		StoragePrefix     string   `json:"storagePrefix"`
 		SerialNumbers     []string `json:"serialNumbers"`
+		FailureDomainZone string   `json:"failureDomainZone"`
 	} `json:"config"`
 	Storage interface{} `json:"storage"`
 	Online  bool        `json:"online"`

--- a/docs/kubernetes/operations/tasks/backends/element.rst
+++ b/docs/kubernetes/operations/tasks/backends/element.rst
@@ -42,6 +42,7 @@ InitiatorIFace     Restrict iSCSI traffic to a specific host interface          
 UseCHAP            Use CHAP to authenticate iSCSI
 AccessGroups       List of Access Group IDs to use                                 Finds the ID of an access group named "trident"
 Types              QoS specifications (see below)
+failureDomainZone  Failure domain zone corresponding to the backend
 ================== =============================================================== ================================================
 
 Example configuration

--- a/docs/kubernetes/operations/tasks/backends/ontap.rst
+++ b/docs/kubernetes/operations/tasks/backends/ontap.rst
@@ -106,6 +106,7 @@ igroupName         Name of the igroup for SAN volumes to use                    
 username           Username to connect to the cluster/SVM
 password           Password to connect to the cluster/SVM
 storagePrefix      Prefix used when provisioning new volumes in the SVM            "trident"
+failureDomainZone  Failure domain zone corresponding to the backend
 ================== =============================================================== ================================================
 
 A fully-qualified domain name (FQDN) can be specified for the managementLIF and dataLIF options. The ontap-san driver

--- a/docs/kubernetes/operations/tasks/backends/santricity.rst
+++ b/docs/kubernetes/operations/tasks/backends/santricity.rst
@@ -60,6 +60,7 @@ hostDataIP            Host iSCSI IP address
 poolNameSearchPattern Regular expression for matching available storage pools         ".+" (all)
 hostType              E-Series Host types created by the driver                       "linux_dm_mp"
 accessGroupName       E-Series Host Group used by the driver                          "trident"
+failureDomainZone     Failure domain zone corresponding to the backend
 ===================== =============================================================== ================================================
 
 Example configuration

--- a/frontend/kubernetes/config.go
+++ b/frontend/kubernetes/config.go
@@ -22,6 +22,9 @@ const (
 	AnnDefaultStorageClass    = "storageclass.kubernetes.io/is-default-class"
 	AnnMountOptions           = "volume.beta.kubernetes.io/mount-options"
 
+	// (Based on kubernetes/pkg/kubelet/apis/well_known_labels.go)
+	LabelZoneFailureDomain    = "failure-domain.beta.kubernetes.io/zone"
+
 	// Orchestrator-defined annotations
 	AnnOrchestrator    = "netapp.io/" + config.OrchestratorName
 	AnnPrefix          = config.OrchestratorName + ".netapp.io"

--- a/storage/backend.go
+++ b/storage/backend.go
@@ -50,7 +50,7 @@ type Driver interface {
 	StoreConfig(b *PersistentStorageBackendConfig)
 	// GetExternalConfig returns a version of the driver configuration that
 	// lacks confidential information, such as usernames and passwords.
-	GetExternalConfig() interface{}
+	GetExternalConfig() drivers.StorageDriverConfigExternal
 	GetVolumeExternal(name string) (*VolumeExternal, error)
 	GetVolumeExternalWrappers(chan *VolumeExternalWrapper)
 	GetUpdateType(driver Driver) *roaring.Bitmap
@@ -281,12 +281,12 @@ func (b *Backend) Terminate() {
 }
 
 type BackendExternal struct {
-	Name     string                   `json:"name"`
-	Protocol tridentconfig.Protocol   `json:"protocol"`
-	Config   interface{}              `json:"config"`
-	Storage  map[string]*PoolExternal `json:"storage"`
-	Online   bool                     `json:"online"`
-	Volumes  []string                 `json:"volumes"`
+	Name     string                              `json:"name"`
+	Protocol tridentconfig.Protocol              `json:"protocol"`
+	Config   drivers.StorageDriverConfigExternal `json:"config"`
+	Storage  map[string]*PoolExternal            `json:"storage"`
+	Online   bool                                `json:"online"`
+	Volumes  []string                            `json:"volumes"`
 }
 
 func (b *Backend) ConstructExternal() *BackendExternal {

--- a/storage_drivers/eseries/eseries_iscsi.go
+++ b/storage_drivers/eseries/eseries_iscsi.go
@@ -874,7 +874,7 @@ func (d *SANStorageDriver) StoreConfig(b *storage.PersistentStorageBackendConfig
 	b.EseriesConfig = &d.Config
 }
 
-func (d *SANStorageDriver) GetExternalConfig() interface{} {
+func (d *SANStorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 	log.Debugln("EseriesStorageDriver:GetExternalConfig")
 
 	return &SANStorageDriverConfigExternal{

--- a/storage_drivers/fake/fake.go
+++ b/storage_drivers/fake/fake.go
@@ -366,7 +366,7 @@ func (d *StorageDriver) StoreConfig(b *storage.PersistentStorageBackendConfig) {
 	}
 }
 
-func (d *StorageDriver) GetExternalConfig() interface{} {
+func (d *StorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 
 	drivers.SanitizeCommonStorageDriverConfig(d.Config.CommonStorageDriverConfig)
 

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -1012,7 +1012,7 @@ func createPrepareCommon(d storage.Driver, volConfig *storage.VolumeConfig) bool
 	return true
 }
 
-func getExternalConfig(config drivers.OntapStorageDriverConfig) interface{} {
+func getExternalConfig(config drivers.OntapStorageDriverConfig) drivers.StorageDriverConfigExternal {
 
 	drivers.SanitizeCommonStorageDriverConfig(config.CommonStorageDriverConfig)
 

--- a/storage_drivers/ontap/ontap_nas.go
+++ b/storage_drivers/ontap/ontap_nas.go
@@ -391,7 +391,7 @@ func (d *NASStorageDriver) StoreConfig(
 	b.OntapConfig = &d.Config
 }
 
-func (d *NASStorageDriver) GetExternalConfig() interface{} {
+func (d *NASStorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 	return getExternalConfig(d.Config)
 }
 

--- a/storage_drivers/ontap/ontap_nas_qtree.go
+++ b/storage_drivers/ontap/ontap_nas_qtree.go
@@ -1021,7 +1021,7 @@ func (d *NASQtreeStorageDriver) StoreConfig(b *storage.PersistentStorageBackendC
 	b.OntapConfig = &d.Config
 }
 
-func (d *NASQtreeStorageDriver) GetExternalConfig() interface{} {
+func (d *NASQtreeStorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 	return getExternalConfig(d.Config)
 }
 

--- a/storage_drivers/ontap/ontap_san.go
+++ b/storage_drivers/ontap/ontap_san.go
@@ -646,7 +646,7 @@ func (d *SANStorageDriver) StoreConfig(
 	b.OntapConfig = &d.Config
 }
 
-func (d *SANStorageDriver) GetExternalConfig() interface{} {
+func (d *SANStorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 	return getExternalConfig(d.Config)
 }
 

--- a/storage_drivers/solidfire/solidfire_san.go
+++ b/storage_drivers/solidfire/solidfire_san.go
@@ -1110,7 +1110,7 @@ func (d *SANStorageDriver) StoreConfig(
 	b.SolidfireConfig = &d.Config
 }
 
-func (d *SANStorageDriver) GetExternalConfig() interface{} {
+func (d *SANStorageDriver) GetExternalConfig() drivers.StorageDriverConfigExternal {
 	endpointHalves := strings.Split(d.Config.EndPoint, "@")
 	return &StorageDriverConfigExternal{
 		CommonStorageDriverConfigExternal: drivers.GetCommonStorageDriverConfigExternal(

--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -25,6 +25,7 @@ type CommonStorageDriverConfig struct {
 	StoragePrefix     *string               `json:"-"`
 	SerialNumbers     []string              `json:"-"`
 	DriverContext     trident.DriverContext `json:"-"`
+	FailureDomainZone string                `json:"failureDomainZone"`
 }
 
 type CommonStorageDriverConfigDefaults struct {
@@ -222,6 +223,15 @@ type CommonStorageDriverConfigExternal struct {
 	StorageDriverName string   `json:"storageDriverName"`
 	StoragePrefix     *string  `json:"storagePrefix"`
 	SerialNumbers     []string `json:"serialNumbers"`
+	FailureDomainZone string   `json:"failureDomainZone"`
+}
+
+type StorageDriverConfigExternal interface {
+	GetFailureDomainZone() string
+}
+
+func (c CommonStorageDriverConfigExternal) GetFailureDomainZone() string {
+	return c.FailureDomainZone
 }
 
 func SanitizeCommonStorageDriverConfig(c *CommonStorageDriverConfig) {
@@ -241,6 +251,7 @@ func GetCommonStorageDriverConfigExternal(
 		StorageDriverName: c.StorageDriverName,
 		StoragePrefix:     c.StoragePrefix,
 		SerialNumbers:     c.SerialNumbers,
+		FailureDomainZone: c.FailureDomainZone,
 	}
 }
 

--- a/trident-installer/sample-input/backend-ontap-san-full.json
+++ b/trident-installer/sample-input/backend-ontap-san-full.json
@@ -7,5 +7,6 @@
     "username": "admin",
     "password": "password123",
     "storagePrefix": "alternate-trident",
-    "igroupName": "custom"
+    "igroupName": "custom",
+    "failureDomainZone": "dc01-a"
 }


### PR DESCRIPTION
Allow to set a `failureDomainZone` parameter for the `backends`.

If it's set and not empty, the value of that parameter will be added to the label `failure-domain.beta.kubernetes.io/zone` to the `PersistentVolume` that are created with that backend.

See: https://github.com/NetApp/trident/issues/148
