### PR TITLE
Trident Plugin - add README.md

### DIFF
--- a/contrib/docker/plugin/README.md
+++ b/contrib/docker/plugin/README.md
@@ -1,0 +1,68 @@
+# Trident - NetApp Docker Volume Plugin
+
+Storage Orchestrator for Containers
+
+## Building Trident Plugin
+
+### Build Requirements
+
+Building the Trident Plugin has the following requirements:
+
+* Must have completed the [BUILD](https://github.com/NetApp/trident/blob/master/BUILD.md) process.
+  * Docker 1.10 or greater when using the Makefile targets.
+  * Go 1.9 or greater is optionally required when building Trident natively.
+  * [Glide](https://github.com/Masterminds/glide) 0.12.2 or greater.
+* And then _`make build`_ (the recommended build process)
+
+> note: the trident repo should be checked out into `$GOPATH/src/github.com/netapp/`
+
+### Build Trident Binary
+
+From the .../netapp/trident/ base directory, execute:
+
+```none
+go build -v
+```
+
+After the build finishes, there should be a file named `trident`. The binary file can be tested by running:
+
+```none
+./trident -h
+```
+
+### Build the Trident Plugin Filesystem
+
+Navigate to the plugin directory.
+
+```none
+cd contrib/docker/plugin
+```
+
+Run the build script.
+
+```none
+make
+```
+
+### Package Files and Push the Trident Plugin to a Local Registry
+
+Requirement:
+
+* A Docker Registry ([https://docs.docker.com/registry/deploying/](https://docs.docker.com/registry/deploying/))
+
+Run the develop plugin script.
+
+```none
+./devPlugin
+```
+
+### Confirm Plugin is Available
+
+```none
+docker plugin ls
+```
+
+## Deploy Plugin
+
+* [https://github.com/NetApp/trident/blob/master/docs/docker/deploying.rst](https://github.com/NetApp/trident/blob/master/docs/docker/deploying.rst)
+* [https://netapp-trident.readthedocs.io/en/stable-v18.04/docker/deploying.html](https://netapp-trident.readthedocs.io/en/stable-v18.04/docker/deploying.html)

--- a/contrib/docker/plugin/pluginname
+++ b/contrib/docker/plugin/pluginname
@@ -1,1 +1,1 @@
-localhost:5000/trident-plugin:18.04.0
+localhost:5000/trident-plugin:latest


### PR DESCRIPTION
I stumbled through the process today to test #151 with no readme. I wrote down the best direct path to building locally I could figure out. After completion, the fix for 151 does work. My team did find the issue, so I thought I would help test  :)

Pull Request Adjustments
- add README.md for the manual process, with requirements, to build the trident plugin.
- adjust the 'pluginname' version to go with industry standard: latest.

Thank you @adkerr 