### PR TITLE
Fix for managementLIF address does not allow port in it #195

### DIFF
--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -142,14 +142,17 @@ func InitializeOntapDriver(config *drivers.OntapStorageDriverConfig) (*api.Clien
 		defer log.WithFields(fields).Debug("<<<< InitializeOntapDriver")
 	}
 
-	addressesFromHostname, err := net.LookupHost(config.ManagementLIF)
+	// Splitting config.ManagementLIF with colon allows to provide managementLIF value as address:port format
+	mgmtLIF := strings.Split(config.ManagementLIF, ":")[0]
+
+	addressesFromHostname, err := net.LookupHost(mgmtLIF)
 	if err != nil {
-		log.WithField("ManagementLIF", config.ManagementLIF).Error("Host lookup failed for ManagementLIF. ", err)
+		log.WithField("ManagementLIF", mgmtLIF).Error("Host lookup failed for ManagementLIF. ", err)
 		return nil, err
 	}
 
 	log.WithFields(log.Fields{
-		"hostname":  config.ManagementLIF,
+		"hostname":  mgmtLIF,
 		"addresses": addressesFromHostname,
 	}).Debug("Addresses found from ManagementLIF lookup.")
 


### PR DESCRIPTION
This PR specifically address the issue https://github.com/NetApp/trident/issues/195 where it allows config.managementLIF to be in the format of `address:port`, as the issue states, current format locks down the port to 443, Trident installation with custom server ports are failing. 