### PR TITLE
Fixing a few `make vet` errors

### DIFF
--- a/storage_drivers/eseries/api/eseries.go
+++ b/storage_drivers/eseries/api/eseries.go
@@ -951,7 +951,6 @@ func (d Client) GetHostForIQN(iqn string) (HostEx, error) {
 			Code:    response.StatusCode,
 			Message: "could not get hosts from array",
 		}
-		return HostEx{}, fmt.Errorf("could not get hosts from array; status code: %d", response.StatusCode)
 	}
 
 	// Parse JSON data

--- a/storage_drivers/eseries/api/types.go
+++ b/storage_drivers/eseries/api/types.go
@@ -181,9 +181,9 @@ type VolumeResizeRequest struct {
 }
 
 type VolumeResizeStatusResponse struct {
-	PercentComplete  int    `json:percentComplete`
-	TimeToCompletion int    `json:timeToCompletion`
-	Action           string `json:action`
+	PercentComplete  int    `json:"percentComplete"`
+	TimeToCompletion int    `json:"timeToCompletion"`
+	Action           string `json:"action"`
 }
 
 type HostCreateRequest struct {

--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -677,7 +677,7 @@ func probeForVolume(name string, client *api.Client) error {
 
 	// Run the volume check using an exponential backoff
 	if err := backoff.RetryNotify(checkVolumeExists, volumeBackoff, volumeExistsNotify); err != nil {
-		log.WithField("volume", name).Warnf("Could not find volume after %3.2f seconds.", volumeBackoff.MaxElapsedTime)
+		log.WithField("volume", name).Warnf("Could not find volume after %3.2f seconds.", volumeBackoff.MaxElapsedTime.Seconds())
 		return fmt.Errorf("volume %v does not exist", name)
 	} else {
 		log.WithField("volume", name).Debug("Volume found.")

--- a/storage_drivers/solidfire/api/volume.go
+++ b/storage_drivers/solidfire/api/volume.go
@@ -80,7 +80,7 @@ func (c *Client) WaitForVolumeByID(volID int64) (Volume, error) {
 	// Run the volume check using an exponential backoff
 	if err := backoff.RetryNotify(checkVolumeExists, volumeBackoff, volumeExistsNotify); err != nil {
 		log.WithField("volumeID", volID).Warnf(
-			"Could not find volume after %3.2f seconds.", volumeBackoff.MaxElapsedTime)
+			"Could not find volume after %3.2f seconds.", volumeBackoff.MaxElapsedTime.Seconds())
 		return volume, fmt.Errorf("volume %d does not exist", volID)
 	} else {
 		log.WithField("volumeID", volID).Debug("Volume found.")


### PR DESCRIPTION
Fixing the following `make vet` errors:
```
# github.com/netapp/trident/storage_drivers/solidfire/api
storage_drivers/solidfire/api/volume.go:82: Entry.Warnf format %3.2f has arg volumeBackoff.MaxElapsedTime of wrong type time.Duration
# github.com/netapp/trident/storage_drivers/eseries/api
storage_drivers/eseries/api/eseries.go:954: unreachable code
storage_drivers/eseries/api/types.go:184: struct field tag `json:percentComplete` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
storage_drivers/eseries/api/types.go:185: struct field tag `json:timeToCompletion` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
storage_drivers/eseries/api/types.go:186: struct field tag `json:action` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
# github.com/netapp/trident/storage_drivers/ontap
storage_drivers/ontap/ontap_common.go:680: Entry.Warnf format %3.2f has arg volumeBackoff.MaxElapsedTime of wrong type time.Duration
```
Some of these also resulted in the failure of `make test_other`:
```
# github.com/netapp/trident/storage_drivers/solidfire/api
storage_drivers/solidfire/api/volume.go:82: Entry.Warnf format %3.2f has arg volumeBackoff.MaxElapsedTime of wrong type time.Duration
# github.com/netapp/trident/storage_drivers/ontap
storage_drivers/ontap/ontap_common.go:680: Entry.Warnf format %3.2f has arg volumeBackoff.MaxElapsedTime of wrong type time.Duration
...
make: *** [test_other] Error 2
```

`make vet` after the fix:
```
[fix_vet_errors] $ make vet
# github.com/netapp/trident/storage_attribute
storage_attribute/types.go:57: struct field selectors has json tag but is not exported
# github.com/netapp/trident/storage_drivers/ontap
storage_drivers/ontap/ontap_common.go:40: struct field done has json tag but is not exported
storage_drivers/ontap/ontap_common.go:41: struct field ticker has json tag but is not exported
storage_drivers/ontap/ontap_common.go:42: struct field stopped has json tag but is not exported
storage_drivers/ontap/ontap_common.go:797: github.com/netapp/trident/storage.Snapshot composite literal uses unkeyed fields
# github.com/netapp/trident/cli/cmd
cli/cmd/get_backend.go:116: github.com/netapp/trident/cli/api.MultipleBackendResponse composite literal uses unkeyed fields
cli/cmd/get_backend.go:118: github.com/netapp/trident/cli/api.MultipleBackendResponse composite literal uses unkeyed fields
cli/cmd/get_storageclass.go:113: github.com/netapp/trident/cli/api.MultipleStorageClassResponse composite literal uses unkeyed fields
cli/cmd/get_storageclass.go:115: github.com/netapp/trident/cli/api.MultipleStorageClassResponse composite literal uses unkeyed fields
cli/cmd/get_volume.go:116: github.com/netapp/trident/cli/api.MultipleVolumeResponse composite literal uses unkeyed fields
cli/cmd/get_volume.go:118: github.com/netapp/trident/cli/api.MultipleVolumeResponse composite literal uses unkeyed fields
make: *** [vet] Error 2
```

`make test_other` after the fix:
```
[fix_vet_errors] $ make test_other
?   	github.com/netapp/trident	[no test files]
?   	github.com/netapp/trident/cli	[no test files]
?   	github.com/netapp/trident/cli/api	[no test files]
?   	github.com/netapp/trident/cli/cmd	[no test files]
?   	github.com/netapp/trident/cli/k8s_client	[no test files]
=== RUN   TestPlatformAtLeast
time="2019-02-26T11:54:08-08:00" level=error msg="Platform version check failed. could not parse \"x123\" as version" platform=kubernetes version=x123
--- PASS: TestPlatformAtLeast (0.00s)
PASS
coverage: 63.6% of statements
ok  	github.com/netapp/trident/config	0.022s	coverage: 63.6% of statements
?   	github.com/netapp/trident/extras/external-etcd/etcd-copy	[no test files]
?   	github.com/netapp/trident/frontend	[no test files]
?   	github.com/netapp/trident/frontend/common	[no test files]
?   	github.com/netapp/trident/frontend/csi	[no test files]
?   	github.com/netapp/trident/frontend/docker	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/netapp/trident/frontend/kubernetes	0.023s	coverage: 0.0% of statements [no tests to run]
?   	github.com/netapp/trident/frontend/rest	[no test files]
?   	github.com/netapp/trident/k8s_client	[no test files]
?   	github.com/netapp/trident/logging	[no test files]
=== RUN   TestBackendState
--- PASS: TestBackendState (0.00s)
    backend_test.go:96: Running test case 'Unknown state'
    backend_test.go:96: Running test case 'Online state'
    backend_test.go:96: Running test case 'Offline state'
    backend_test.go:96: Running test case 'Deleting state'
    backend_test.go:96: Running test case 'Failed state'
    backend_test.go:96: Running test case 'Unknown state (bad)'
PASS
coverage: 7.2% of statements
ok  	github.com/netapp/trident/storage	0.027s	coverage: 7.2% of statements
=== RUN   TestConstructExternalBackend
--- PASS: TestConstructExternalBackend (0.00s)
PASS
coverage: 0.0% of statements
ok  	github.com/netapp/trident/storage/external_test	0.020s	coverage: 0.0% of statements
=== RUN   TestInitializeRecovery
time="2019-02-26T11:54:08-08:00" level=error msg="API invocation failed. Post https://127.0.0.1/servlets/netapp.servlets.admin.XMLrequest_filer: dial tcp 127.0.0.1:443: connect: connection refused"
--- PASS: TestInitializeRecovery (0.00s)
PASS
coverage: 44.1% of statements
ok  	github.com/netapp/trident/storage/factory	0.022s	coverage: 44.1% of statements
?   	github.com/netapp/trident/storage/fake	[no test files]
=== RUN   TestMatches
--- PASS: TestMatches (0.00s)
=== RUN   TestUnmarshalOffer
--- PASS: TestUnmarshalOffer (0.00s)
=== RUN   TestUnmarshalRequest
--- PASS: TestUnmarshalRequest (0.00s)
PASS
coverage: 76.9% of statements
ok  	github.com/netapp/trident/storage_attribute	0.012s	coverage: 76.9% of statements
?   	github.com/netapp/trident/storage_class	[no test files]
=== RUN   TestGetCommonInternalVolumeName
--- PASS: TestGetCommonInternalVolumeName (0.00s)
PASS
coverage: 7.0% of statements
ok  	github.com/netapp/trident/storage_drivers	0.022s	coverage: 7.0% of statements
?   	github.com/netapp/trident/storage_drivers/aws	[no test files]
?   	github.com/netapp/trident/storage_drivers/aws/api	[no test files]
?   	github.com/netapp/trident/storage_drivers/eseries	[no test files]
?   	github.com/netapp/trident/storage_drivers/eseries/api	[no test files]
=== RUN   TestNewConfig
--- PASS: TestNewConfig (0.00s)
=== RUN   TestAttributeMatches
--- PASS: TestAttributeMatches (0.00s)
=== RUN   TestAttributeMatchesWithVirtualPools
--- PASS: TestAttributeMatchesWithVirtualPools (0.00s)
=== RUN   TestSpecificBackends
--- PASS: TestSpecificBackends (0.00s)
=== RUN   TestRegex
--- PASS: TestRegex (0.00s)
=== RUN   TestRegex2
--- PASS: TestRegex2 (0.00s)
PASS
coverage: 37.3% of statements
ok  	github.com/netapp/trident/storage_drivers/fake	0.025s	coverage: 37.3% of statements
?   	github.com/netapp/trident/storage_drivers/fake/test_utils	[no test files]
?   	github.com/netapp/trident/storage_drivers/ontap	[no test files]
=== RUN   TestGetError
--- PASS: TestGetError (0.00s)
PASS
coverage: 2.9% of statements
ok  	github.com/netapp/trident/storage_drivers/ontap/api	0.016s	coverage: 2.9% of statements
?   	github.com/netapp/trident/storage_drivers/ontap/api/azgo	[no test files]
=== RUN   TestGetExternalConfig
--- PASS: TestGetExternalConfig (0.00s)
    solidfire_test.go:75: External config endpoint:   https://10.63.171.151/json-rpc/7.0
    solidfire_test.go:82: Main config endpoint:   https://admin:solidfire@10.63.171.151/json-rpc/7.0
=== RUN   TestUpgradeOlderEndpointAPIVersion
time="2019-02-26T11:54:09-08:00" level=warning msg="Overriding config file with minimum SF API version." minVersion=8.0
--- PASS: TestUpgradeOlderEndpointAPIVersion (0.00s)
=== RUN   TestNoUpgradeNewerEndpointAPIVersion
--- PASS: TestNoUpgradeNewerEndpointAPIVersion (0.00s)
=== RUN   TestGetEndpointCredentials
time="2019-02-26T11:54:09-08:00" level=error msg="could not determine credentials: parse ://admin:solidfire@10.63.171.151/json-rpc/9.0: missing protocol scheme"
--- PASS: TestGetEndpointCredentials (0.00s)
PASS
coverage: 4.4% of statements
ok  	github.com/netapp/trident/storage_drivers/solidfire	0.018s	coverage: 4.4% of statements
?   	github.com/netapp/trident/storage_drivers/solidfire/api	[no test files]
=== RUN   TestLockCreated
--- PASS: TestLockCreated (0.00s)
=== RUN   TestLockReused
--- PASS: TestLockReused (0.00s)
=== RUN   TestLockBehavior
--- PASS: TestLockBehavior (0.01s)
=== RUN   TestPow
--- PASS: TestPow (0.00s)
=== RUN   TestConvertSizeToBytes
--- PASS: TestConvertSizeToBytes (0.00s)
=== RUN   TestGetV
--- PASS: TestGetV (0.00s)
=== RUN   TestVolumeSizeWithinTolerance
--- PASS: TestVolumeSizeWithinTolerance (0.00s)
=== RUN   TestSemanticVersions
--- PASS: TestSemanticVersions (0.00s)
=== RUN   TestBadSemanticVersions
--- PASS: TestBadSemanticVersions (0.00s)
=== RUN   TestDateVersions
--- PASS: TestDateVersions (0.00s)
=== RUN   TestBadDateVersions
--- PASS: TestBadDateVersions (0.00s)
=== RUN   TestGenericVersions
--- PASS: TestGenericVersions (0.00s)
=== RUN   TestBadGenericVersions
--- PASS: TestBadGenericVersions (0.00s)
PASS
coverage: 15.7% of statements
ok  	github.com/netapp/trident/utils	0.025s	coverage: 15.7% of statements
```