### PR TITLE
cvs-aws: fixed storage class, improved API endpoint documentation

### DIFF
--- a/trident-installer/sample-input/backend-aws-cvs-advanced.json
+++ b/trident-installer/sample-input/backend-aws-cvs-advanced.json
@@ -2,7 +2,7 @@
   "version": 1,
   "storageDriverName": "aws-cvs",
   "apiRegion": "us-east-1",
-  "apiURL": "https://cds-aws-bundles.netapp.com:8080/v1",
+  "apiURL": "https://cds-aws-bundles.netapp.com:8080/v1 for us-east-1, https://cv.<apiRegion>.netapp.com:8080/v1 for all other regions",
   "apiKey": "znHczZsrrtHisIsAbOguSaPIKeyAZNchRAGzlzZE",
   "secretKey": "rR0rUmWXfNioN1KhtHisiSAnoTherboGuskey6pU",
   "nfsMountOptions": "vers=3,proto=tcp,timeo=600",
@@ -14,7 +14,6 @@
   },
 
   "labels": {"cloud": "aws"},
-  "region": "us-east-1",
 
   "storage": [
     {

--- a/trident-installer/sample-input/backend-aws-cvs.json
+++ b/trident-installer/sample-input/backend-aws-cvs.json
@@ -2,7 +2,7 @@
   "version": 1,
   "storageDriverName": "aws-cvs",
   "apiRegion": "us-east-1",
-  "apiURL": "https://cds-aws-bundles.netapp.com:8080/v1",
+  "apiURL": "https://cds-aws-bundles.netapp.com:8080/v1 for us-east-1, https://cv.<apiRegion>.netapp.com:8080/v1 for all other regions",
   "apiKey": "znHczZsrrtHisIsAbOguSaPIKeyAZNchRAGzlzZE",
   "secretKey": "rR0rUmWXfNioN1KhtHisiSAnoTherboGuskey6pU"
 }

--- a/trident-installer/sample-input/storage-class-aws-cvs-advanced.yaml
+++ b/trident-installer/sample-input/storage-class-aws-cvs-advanced.yaml
@@ -1,26 +1,26 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-name: cvs-extreme
+  name: cvs-extreme
 provisioner: netapp.io/trident
 parameters:
-selector: "performance=extreme"
+  selector: "performance=extreme"
 allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-name: cvs-premium
+  name: cvs-premium
 provisioner: netapp.io/trident
 parameters:
-selector: "performance=premium"
+  selector: "performance=premium"
 allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-name: cvs-standard
+  name: cvs-standard
 provisioner: netapp.io/trident
 parameters:
-selector: "performance=standard"
+  selector: "performance=standard"
 allowVolumeExpansion: true


### PR DESCRIPTION
The storage classes were malformed. Fixed.
The CVS API endpoint is `https://cds-aws-bundles.netapp.com:8080/v1` for us-east-1 (lets call it a legacy endpoint), but `https://cv.<apiRegion>.netapp.com:8080/v1` for all other CVS regions. Having this knowledge in the backend file yields quicker success.