### PR TITLE
Fix OpenShift version discovery for 4.x

### DIFF
--- a/cli/k8s_client/k8s_cli_client.go
+++ b/cli/k8s_client/k8s_cli_client.go
@@ -50,7 +50,10 @@ func NewKubectlClient(namespace string) (Interface, error) {
 		k8sVersion, err = discoverKubernetesServerVersion(cli)
 	case CLIOpenShift:
 		flavor = FlavorOpenShift
-		k8sVersion, err = discoverOpenShiftServerVersion(cli)
+		k8sVersion, err = discoverKubernetesServerVersion(cli)
+		if err != nil {
+			k8sVersion, err = discoverOpenShiftServerVersion(cli)
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
OpenShift 4.x client returns a version string that looks like Kubernetes
so if the `oc` binary exists we should first check to see if we have a
Kubernetes-like version string and if not fall back to checking for a
OpenShift 3.x style string.

I have done some minimal testing so far and will continue to test today
on my OCP 4.x cluster 