### PR TITLE
Update deploying.rst

### DIFF
--- a/docs/kubernetes/deploying.rst
+++ b/docs/kubernetes/deploying.rst
@@ -296,7 +296,7 @@ installer, replacing ``__BACKEND_TYPE__`` with the storage driver name.
     | nas-backend | ontap-nas      | 98e19b74-aec7-4a3d-8dcf-128e5033b214 | online |       0 |
     +-------------+----------------+--------------------------------------+--------+---------+
 
-    cp sample-input/storage-class-csi.yaml.templ sample-input/storage-class-basic.yaml
+    cp sample-input/storage-class-basic.yaml.templ sample-input/storage-class-basic.yaml
 
     # Modify __BACKEND_TYPE__ with the storage driver field above (e.g., ontap-nas)
     vi sample-input/storage-class-basic.yaml


### PR DESCRIPTION
storage-class-basic.yaml.templ  should be used, not csi, otherwise the rest of the examples (kubectl get sc basic for instance) wont work since it will look for csi.