### PR TITLE
Fix SC cvs-extreme-standard-protection

### DIFF
--- a/docs/kubernetes/operations/tasks/backends/cvs_aws.rst
+++ b/docs/kubernetes/operations/tasks/backends/cvs_aws.rst
@@ -199,7 +199,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
       name: cvs-extreme-standard-protection
     provisioner: netapp.io/trident
     parameters:
-      selector: "performance=premium; protection=standard"
+      selector: "performance=extreme; protection=standard"
     allowVolumeExpansion: true
     ---
     apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
StorageClass cvs-extreme-standard-protection should have selector: "performance=extreme; protection=standard" instead of performance=premium. 