### PR TITLE
Fix no Auth Provider found error

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/netapp/trident/cli/api"
 	"github.com/netapp/trident/config"
+
+	// Load all auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const (


### PR DESCRIPTION
This PR fixes no Auth Provider found error by loading all auth plugins.

/fixes #348 

*I've already signed NetApp CLA.*