### PR TITLE
Added support for Adaptive QoS policies with ontap backends

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99 h1:twflg0XRTjwKpxb/jFExr4HGq6on2dEOmnL6FV+fgPw=
 github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/storage_drivers/ontap/api/azgo/api-clone-create.go
+++ b/storage_drivers/ontap/api/azgo/api-clone-create.go
@@ -26,6 +26,7 @@ type CloneCreateRequest struct {
 	LunSerialNumberPtr    *string                        `xml:"lun-serial-number"`
 	NosplitEntryPtr       *bool                          `xml:"nosplit-entry"`
 	QosPolicyGroupNamePtr *string                        `xml:"qos-policy-group-name"`
+	QosAdaptivePolicyGroupNamePtr *string                `xml:"qos-adaptive-policy-group-name"`
 	SnapshotNamePtr       *string                        `xml:"snapshot-name"`
 	SourcePathPtr         *string                        `xml:"source-path"`
 	SpaceReservePtr       *bool                          `xml:"space-reserve"`
@@ -336,6 +337,18 @@ func (o *CloneCreateRequest) QosPolicyGroupName() string {
 // SetQosPolicyGroupName is a fluent style 'setter' method that can be chained
 func (o *CloneCreateRequest) SetQosPolicyGroupName(newValue string) *CloneCreateRequest {
 	o.QosPolicyGroupNamePtr = &newValue
+	return o
+}
+
+// QosAdaptivePolicyGroupName is a 'getter' method
+func (o *CloneCreateRequest) QosAdaptivePolicyGroupName() string {
+	r := *o.QosAdaptivePolicyGroupNamePtr
+	return r
+}
+
+// SetQosAdaptivePolicyGroupName is a fluent style 'setter' method that can be chained
+func (o *CloneCreateRequest) SetQosAdaptivePolicyGroupName(newValue string) *CloneCreateRequest {
+	o.QosAdaptivePolicyGroupNamePtr = &newValue
 	return o
 }
 

--- a/storage_drivers/ontap/api/azgo/api-lun-create-by-size.go
+++ b/storage_drivers/ontap/api/azgo/api-lun-create-by-size.go
@@ -19,6 +19,7 @@ type LunCreateBySizeRequest struct {
 	PathPtr                    *string        `xml:"path"`
 	PrefixSizePtr              *int           `xml:"prefix-size"`
 	QosPolicyGroupPtr          *string        `xml:"qos-policy-group"`
+	QosAdaptivePolicyGroupPtr  *string        `xml:"qos-adaptive-policy-group"`
 	SizePtr                    *int           `xml:"size"`
 	SpaceAllocationEnabledPtr  *bool          `xml:"space-allocation-enabled"`
 	SpaceReservationEnabledPtr *bool          `xml:"space-reservation-enabled"`
@@ -221,6 +222,18 @@ func (o *LunCreateBySizeRequest) QosPolicyGroup() string {
 // SetQosPolicyGroup is a fluent style 'setter' method that can be chained
 func (o *LunCreateBySizeRequest) SetQosPolicyGroup(newValue string) *LunCreateBySizeRequest {
 	o.QosPolicyGroupPtr = &newValue
+	return o
+}
+
+// QosAdaptivePolicyGroup is a 'getter' method
+func (o *LunCreateBySizeRequest) QosAdaptivePolicyGroup() string {
+	r := *o.QosAdaptivePolicyGroupPtr
+	return r
+}
+
+// SetQosAdaptivePolicyGroup is a fluent style 'setter' method that can be chained
+func (o *LunCreateBySizeRequest) SetQosAdaptivePolicyGroup(newValue string) *LunCreateBySizeRequest {
+	o.QosAdaptivePolicyGroupPtr = &newValue
 	return o
 }
 

--- a/storage_drivers/ontap/api/azgo/type-volume-qos-attributes.go
+++ b/storage_drivers/ontap/api/azgo/type-volume-qos-attributes.go
@@ -33,18 +33,6 @@ func (o VolumeQosAttributesType) String() string {
 	return ToString(reflect.ValueOf(o))
 }
 
-// AdaptivePolicyGroupName is a 'getter' method
-func (o *VolumeQosAttributesType) AdaptivePolicyGroupName() string {
-	r := *o.AdaptivePolicyGroupNamePtr
-	return r
-}
-
-// SetAdaptivePolicyGroupName is a fluent style 'setter' method that can be chained
-func (o *VolumeQosAttributesType) SetAdaptivePolicyGroupName(newValue string) *VolumeQosAttributesType {
-	o.AdaptivePolicyGroupNamePtr = &newValue
-	return o
-}
-
 // PolicyGroupName is a 'getter' method
 func (o *VolumeQosAttributesType) PolicyGroupName() string {
 	r := *o.PolicyGroupNamePtr
@@ -54,5 +42,17 @@ func (o *VolumeQosAttributesType) PolicyGroupName() string {
 // SetPolicyGroupName is a fluent style 'setter' method that can be chained
 func (o *VolumeQosAttributesType) SetPolicyGroupName(newValue string) *VolumeQosAttributesType {
 	o.PolicyGroupNamePtr = &newValue
+	return o
+}
+
+// AdaptivePolicyGroupName is a 'getter' method
+func (o *VolumeQosAttributesType) AdaptivePolicyGroupName() string {
+	r := *o.AdaptivePolicyGroupNamePtr
+	return r
+}
+
+// SetAdaptivePolicyGroupName is a fluent style 'setter' method that can be chained
+func (o *VolumeQosAttributesType) SetAdaptivePolicyGroupName(newValue string) *VolumeQosAttributesType {
+	o.AdaptivePolicyGroupNamePtr = &newValue
 	return o
 }

--- a/storage_drivers/ontap/ontap_nas.go
+++ b/storage_drivers/ontap/ontap_nas.go
@@ -246,6 +246,8 @@ func (d *NASStorageDriver) Create(
 	createErrors := make([]error, 0)
 	physicalPoolNames := make([]string, 0)
 
+        adaptivePolicyGroupName := d.Config.AdaptivePolicyGroupName
+
 	for _, physicalPool := range physicalPools {
 		aggregate := physicalPool.Name
 		physicalPoolNames = append(physicalPoolNames, aggregate)
@@ -260,7 +262,7 @@ func (d *NASStorageDriver) Create(
 		// Create the volume
 		volCreateResponse, err := d.API.VolumeCreate(
 			name, aggregate, size, spaceReserve, snapshotPolicy, unixPermissions,
-			exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt)
+			exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt, adaptivePolicyGroupName)
 
 		if err = api.GetError(volCreateResponse, err); err != nil {
 			if zerr, ok := err.(api.ZapiError); ok {

--- a/storage_drivers/ontap/ontap_nas_flexgroup.go
+++ b/storage_drivers/ontap/ontap_nas_flexgroup.go
@@ -509,10 +509,12 @@ func (d *NASFlexGroupStorageDriver) Create(
 	physicalPoolNames := make([]string, 0)
 	physicalPoolNames = append(physicalPoolNames, d.physicalPool.Name)
 
+        adaptivePolicyGroupName := d.Config.AdaptivePolicyGroupName
+
 	// Create the FlexGroup
 	_, err = d.API.FlexGroupCreate(
 		name, size, vserverAggrNames, spaceReserve, snapshotPolicy, unixPermissions,
-		exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt)
+		exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt, adaptivePolicyGroupName)
 
 	if err != nil {
 		createErrors = append(createErrors, fmt.Errorf("ONTAP-NAS-FLEXGROUP pool %s; error creating FlexGroup %v: %v", storagePool.Name, name, err))

--- a/storage_drivers/ontap/ontap_nas_qtree.go
+++ b/storage_drivers/ontap/ontap_nas_qtree.go
@@ -685,10 +685,12 @@ func (d *NASQtreeStorageDriver) createFlexvolForQtree(
 		"encryption":      enableEncryption,
 	}).Debug("Creating Flexvol for qtrees.")
 
+        adaptivePolicyGroupName := d.Config.AdaptivePolicyGroupName
+
 	// Create the Flexvol
 	createResponse, err := d.API.VolumeCreate(
 		flexvol, aggregate, size, spaceReserve, snapshotPolicy, unixPermissions,
-		exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt)
+		exportPolicy, securityStyle, tieringPolicy, enableEncryption, snapshotReserveInt, adaptivePolicyGroupName)
 	if err = api.GetError(createResponse, err); err != nil {
 		return "", fmt.Errorf("error creating Flexvol: %v", err)
 	}

--- a/storage_drivers/ontap/ontap_san_economy.go
+++ b/storage_drivers/ontap/ontap_san_economy.go
@@ -449,6 +449,9 @@ func (d *SANEconomyStorageDriver) Create(
 	createErrors := make([]error, 0)
 	physicalPoolNames := make([]string, 0)
 
+        // For the ONTAP SAN economy driver, we set the QoS policy at the LUN layer.
+        adaptivePolicyGroupName := d.Config.AdaptivePolicyGroupName
+
 	for _, physicalPool := range physicalPools {
 		aggregate := physicalPool.Name
 		physicalPoolNames = append(physicalPoolNames, aggregate)
@@ -487,7 +490,8 @@ func (d *SANEconomyStorageDriver) Create(
 		osType := "linux"
 
 		// Create the LUN
-		lunCreateResponse, err := d.API.LunCreate(lunPath, int(sizeBytes), osType, false, spaceAllocation)
+                // For the ONTAP SAN economy driver, we set the QoS policy at the LUN layer.
+		lunCreateResponse, err := d.API.LunCreate(lunPath, int(sizeBytes), osType, false, spaceAllocation, adaptivePolicyGroupName)
 		if err = api.GetError(lunCreateResponse, err); err != nil {
 			errMessage := fmt.Sprintf("ONTAP-SAN-ECONOMY pool %s/%s; error creating LUN %s/%s: %v", storagePool.Name,
 				aggregate, bucketVol, name, err)
@@ -581,7 +585,9 @@ func (d *SANEconomyStorageDriver) createLUNClone(
 	}
 
 	// Create the clone based on given LUN
-	cloneResponse, err := client.LunCloneCreate(flexvol, source, lunName)
+        // For the ONTAP SAN economy driver, we set the QoS policy at the LUN layer.
+        adaptivePolicyGroupName := d.Config.AdaptivePolicyGroupName
+	cloneResponse, err := client.LunCloneCreate(flexvol, source, lunName, adaptivePolicyGroupName)
 	if err != nil {
 		return fmt.Errorf("error creating clone: %v", err)
 	}
@@ -1194,10 +1200,13 @@ func (d *SANEconomyStorageDriver) createFlexvolForLUN(
 		"encryption":      encryption,
 	}).Debug("Creating Flexvol for LUNs.")
 
+        // For the ONTAP SAN economy driver, we set the QoS policy at the LUN layer.
+        adaptivePolicyGroupName := ""
+
 	// Create the flexvol
 	volCreateResponse, err := d.API.VolumeCreate(
 		flexvol, aggregate, size, spaceReserve, snapshotPolicy,
-		unixPermissions, exportPolicy, securityStyle, tieringPolicy, encrypt, snapshotReserveInt)
+		unixPermissions, exportPolicy, securityStyle, tieringPolicy, encrypt, snapshotReserveInt, adaptivePolicyGroupName)
 
 	if err = api.GetError(volCreateResponse, err); err != nil {
 		return "", fmt.Errorf("error creating volume: %v", err)

--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -89,6 +89,7 @@ type OntapStorageDriverConfig struct {
 	LimitAggregateUsage              string   `json:"limitAggregateUsage"`
 	AutoExportPolicy                 bool     `json:"autoExportPolicy"`
 	AutoExportCIDRs                  []string `json:"autoExportCIDRs"`
+        AdaptivePolicyGroupName          string   `json:"adaptivePolicyGroupName"`
 	OntapStorageDriverPool
 	Storage                   []OntapStorageDriverPool `json:"storage"`
 	UseCHAP                   bool                     `json:"useCHAP"`


### PR DESCRIPTION
Added support for Adaptive QoS policies that have been pre-created on
the storage system, for all the ontap backends.  The Adaptive QoS
policy is applied at the volume level for all ontap backends except
for the san-economy driver, where it is applied at the LUN level.
For the nas-economy driver, this means that all PVCs share the
same Adaptive QoS policy group, but this is the best we can do at
this point given what is supported by ONTAP.

To use this feature, configure a Trident backend with with the
adaptivePolicyGroupname as part of the backend per the following example:

{
    "version": 1,
    "storageDriverName": "ontap-nas",
    "backendName": "simple-aqos",
    "managementLIF": "ontapsim1",
    "svm": "vs1",
    "username": "admin",
    "password": "netapp123",
    "adaptivePolicyGroupName": "policy1",
}

Note that a cluster scoped account must be used in the driver
configuration in order to use QoS in clustered ONTAP.  Also note
that support for setting the adaptivePolicyGroupName has been
implemented at the backend driver layer, rather than as a Trident
volume defaults setting, so that end users cannot change the
Adaptive QoS policy on a per PVC basis.  The idea is that Adaptive
QoS should be defined and enforced by the storage administrator and
the Kubernetes administrator, not by the end user.