### PR TITLE
Expose kubelet_volume* metrics

### DIFF
--- a/frontend/csi/plugin.go
+++ b/frontend/csi/plugin.go
@@ -99,6 +99,7 @@ func NewNodePlugin(
 	p.addNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	})
 
 	port := os.Getenv("TRIDENT_CSI_SERVICE_PORT")
@@ -163,6 +164,7 @@ func NewAllInOnePlugin(
 	p.addNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 	})
 	port := "34571"
 	for _, envVar := range os.Environ() {


### PR DESCRIPTION
Possible fix for https://github.com/NetApp/trident/issues/134

This should work on all/most linux processor architectures but not on windows. Currently only a PoC to showcase that this can be implemented in quite an easy way.

Feedback is very welcome 😃 

