### PR TITLE
Add note on behavior of the solidfire-san driver

### DIFF
--- a/docs/docker/use/volumes.rst
+++ b/docs/docker/use/volumes.rst
@@ -52,6 +52,8 @@ Destroy a Volume
    # destroy the volume just like any other Docker volume
    docker volume rm firstVolume
 
+Please note that when using the solidfire-san driver, the above example deletes and purges the volume.
+
 Volume Cloning
 --------------
 


### PR DESCRIPTION
Element DeleteVolume marks an active volume for deletion. It is purged (permanently deleted) after the cleanup interval elapses.
Here it's purged instantly, which is useful for environments where many volumes get created and deleted, but not the standard behavior.
Perhaps a similar note should be added to the K8s section but I don't have a K8s cluster to verify it.