### PR TITLE
Update drivers.rst

### DIFF
--- a/docs/kubernetes/operations/tasks/backends/ontap/drivers.rst
+++ b/docs/kubernetes/operations/tasks/backends/ontap/drivers.rst
@@ -20,10 +20,8 @@ Driver              Protocol Mount Type Access Modes Supported
 ontap-nas           NFS      File       RWO,RWX,ROX
 ontap-nas-economy   NFS      File       RWO,RWX,ROX
 ontap-nas-flexgroup NFS      File       RWO,RWX,ROX
-ontap-san           iSCSI    Block      RWO,ROX,RWX
-ontap-san-economy   iSCSI    Block      RWO,ROX,RWX
-ontap-san           iSCSI    File       RWO,ROX
-ontap-san-economy   iSCSI    File       RWO,ROX
+ontap-san           iSCSI    Block      RWO,ROX
+ontap-san-economy   iSCSI    Block      RWO,ROX
 =================== ======== ========== ======================
 
 .. note::


### PR DESCRIPTION
Fix #451 

There is a mistake with the supported access mode for ontap-san & ontap-san-economy drivers in the Trident documentation, in the section [drivers for ONTAP](https://github.com/NetApp/trident/blob/stable/v20.07/docs/kubernetes/operations/tasks/backends/ontap/drivers.rst).
The mount type for the ontap-san drivers is block, not file, and iSCSI only supports ReadWriteOnce and ReadOnlyMany access mode based on the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).