### PR TITLE
Fixes autosupportImage being prepend with image registry url

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -244,9 +244,6 @@ func discoverInstallationEnvironment() error {
 	}
 	log.Debugf("Trident image: %s", tridentImage)
 
-	if imageRegistry != "" {
-		autosupportImage = utils.ReplaceImageRegistry(autosupportImage, imageRegistry)
-	}
 	log.Debugf("Autosupport image: %s", autosupportImage)
 
 	// Create the Kubernetes client


### PR DESCRIPTION
Should fix https://github.com/NetApp/trident/issues/459