### PR TITLE
Verify Azure API works before enabling ANF backend

### DIFF
--- a/storage_drivers/azure/azure_anf.go
+++ b/storage_drivers/azure/azure_anf.go
@@ -427,7 +427,7 @@ func (d *NFSStorageDriver) initializeAzureSDKClient(
 		DebugTraceFlags: config.DebugTraceFlags,
 	})
 
-	if err := client.SDKClient.Authenticate(); err != nil {
+	if err := client.SDKClient.Authenticate(ctx); err != nil {
 		return nil, err
 	}
 

--- a/storage_drivers/azure/sdk/azure_test.go
+++ b/storage_drivers/azure/sdk/azure_test.go
@@ -3,10 +3,47 @@
 package sdk
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// The Azure NetApp Files backend will report itself as being "online" even when
+// provided bad credentials. This will cause PersistentVolumeClaims to fail at
+// provisioning time with a "no capacity pools found" error.
+//
+// This test ensures that Authenticate(c *AzureClient) fails when it cannot
+// retrieve an ADAL token with the ServicePrincipal credentials provided.
+//
+// Because of the way that go-azure is designed, we have to make a dummy API call and
+// have it fail in order to verify that we can receive a token. The easiest
+// client to do that with is the virtualNetworks client, so that's what we'll use.
+
+func TestConfirmAzureAPIAccessibleFirstFail(t *testing.T) {
+	oldAttemptToResolveVirtualNetworks := attemptToResolveVirtualNetworks
+	defer func() { attemptToResolveVirtualNetworks = oldAttemptToResolveVirtualNetworks }()
+	attemptToResolveVirtualNetworks = func(c *AzureClient, ctx context.Context) error {
+		return errors.New("Test failure")
+	}
+	azureClient := new(AzureClient)
+	err := confirmAzureAPIAccessibleFirst(azureClient, context.TODO())
+	t.Logf("Running test case: Confirm that Azure API is accessible first, Fail")
+	assert.EqualError(t, err, "Failed to access the Azure API: Test failure")
+}
+
+func TestConfirmAzureAPIAccessibleFirstSuccess(t *testing.T) {
+	oldAttemptToResolveVirtualNetworks := attemptToResolveVirtualNetworks
+	defer func() { attemptToResolveVirtualNetworks = oldAttemptToResolveVirtualNetworks }()
+	attemptToResolveVirtualNetworks = func(c *AzureClient, ctx context.Context) error {
+		return nil
+	}
+	azureClient := new(AzureClient)
+	t.Logf("Running test case: Confirm that Azure API is accessible first, Success")
+	obj := confirmAzureAPIAccessibleFirst(azureClient, context.TODO())
+	assert.Nil(t, obj)
+}
 
 func TestPoolShortname(t *testing.T) {
 


### PR DESCRIPTION
Fixes [issue #465](https://github.com/NetApp/trident/issues/465)

**Describe the solution you'd like**
As of v20.04, the Azure NetApp Files backend will report itself as being `online` even if its `backend.json` contains invalid credentials. The backend should report itself as being `offline` or `failed` in this scenario.

**Describe alternatives you've considered**
The current workaround is to initialize the backend with `tridentctl create backend` and then attempt to provision a volume through a `PersistentVolumeClaim` or wait for capacity pool discovery to take place.