### PR TITLE
Allow numbers in storage prefix on ONTAP

### DIFF
--- a/storage_drivers/ontap/ontap_common.go
+++ b/storage_drivers/ontap/ontap_common.go
@@ -1316,7 +1316,7 @@ func ValidateNASDriver(ctx context.Context, api *api.Client, config *drivers.Ont
 func ValidateStoragePrefix(storagePrefix string) error {
 
 	// Ensure storage prefix is compatible with ONTAP
-	matched, err := regexp.MatchString(`^$|^[a-zA-Z_.-][a-zA-Z0-9_.-]*$`, storagePrefix)
+	matched, err := regexp.MatchString(`^$|^[a-zA-Z0-9_.-]*$`, storagePrefix)
 	if err != nil {
 		err = fmt.Errorf("could not check storage prefix; %v", err)
 	} else if !matched {


### PR DESCRIPTION
Volumes created with a prefix starting with a number created before
commit c262e4ca7966700dfc48276c86a26ee7c82c71c9 no longer work on newer
versions of trident, as the prefix matcher doesn't accept them.

Accepting prefixes starting with a number is OK as the prefix is not
actually the first part of the volume name.