### PR TITLE
Cleanup output that looks like input

### DIFF
--- a/docs/kubernetes/upgrades/operator-upgrade.rst
+++ b/docs/kubernetes/upgrades/operator-upgrade.rst
@@ -158,11 +158,11 @@ set of steps to be followed:
 
      #Delete the namespace-scoped operator
      $ kubectl delete -f deploy/bundle.yaml
-     $ serviceaccount "trident-operator" deleted
-     $ clusterrole.rbac.authorization.k8s.io "trident-operator" deleted
-     $ clusterrolebinding.rbac.authorization.k8s.io "trident-operator" deleted
-     $ deployment.apps "trident-operator" deleted
-     $ podsecuritypolicy.policy "tridentoperatorpods" deleted
+     serviceaccount "trident-operator" deleted
+     clusterrole.rbac.authorization.k8s.io "trident-operator" deleted
+     clusterrolebinding.rbac.authorization.k8s.io "trident-operator" deleted
+     deployment.apps "trident-operator" deleted
+     podsecuritypolicy.policy "tridentoperatorpods" deleted
 
      #Confirm the Trident operator was removed
      $ kubectl get all -n trident


### PR DESCRIPTION
The output from "kubectl delete -f deploy/bundle.yaml" is formatted to look like further input, e.g. "$ serviceaccount "trident-operator" deleted" - this seems to by a typo and could be confusing to people copy-and-pasting from the instructions.