### PR TITLE
Fix for Helm's conditions for K8s pre- and patch-release (#530) 

### DIFF
--- a/helm/trident-operator/Chart.yaml
+++ b/helm/trident-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trident-operator
 version: 1.0.0
-kubeVersion: ">= 1.16.0 < 1.21.0-0"
+kubeVersion: ">= 1.16.0-0, < 1.21.0-0"
 description: "A Helm chart for deploying NetApp's Trident CSI storage provisioner using the Trident Operator."
 type: application
 keywords: ["NetApp", "Trident", "operator", "CSI"]

--- a/helm/trident-operator/Chart.yaml
+++ b/helm/trident-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trident-operator
 version: 1.0.0
-kubeVersion: ">= 1.16.0 < 1.21.0"
+kubeVersion: ">= 1.16.0 < 1.21.0-0"
 description: "A Helm chart for deploying NetApp's Trident CSI storage provisioner using the Trident Operator."
 type: application
 keywords: ["NetApp", "Trident", "operator", "CSI"]


### PR DESCRIPTION
The previously closed PR didn't work because Helm evaluates the both conditions in Chart.yaml. 
When multiple conditions are present, all formats have to be able to handle K8s version format.

Test:

```
ubuntu@ubuntuguest:~/trident/helm$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.3", GitCommit:"01849e73f3c86211f05533c2e807736e776fcf29", GitTreeState:"clean", BuildDate:"2021-02-17T12:44:29Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.2-34+350770ed07a558", GitCommit:"350770ed07a558ba1ce8202a6f9ea849f9a75f06", GitTreeState:"clean", BuildDate:"2021-02-11T20:10:29Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}

ubuntu@ubuntuguest:~/trident/helm$ helm version
version.BuildInfo{Version:"v3.5.2", GitCommit:"167aac70832d3a384f65f9745335e9fb40169dc2", GitTreeState:"dirty", GoVersion:"go1.15.7"}

ubuntu@ubuntuguest:~/trident/helm$ cat trident-operator/Chart.yaml| grep "1.2"
kubeVersion: ">= 1.16.0-0, < 1.21.0-0"

ubuntu@ubuntuguest:~/trident/helm$ helm install trident trident-operator --namespace trident
NAME: trident
LAST DEPLOYED: Thu Feb 18 10:06:20 2021
NAMESPACE: trident
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing trident-operator, which will deploy and manage NetApp's Trident CSI
storage provisioner for Kubernetes.

Your release is named 'trident' and is installed into the 'trident' namespace.
Please note that there must be only one instance of Trident (and trident-operator) in a Kubernetes cluster.

To configure Trident to manage storage resources, you will need a copy of tridentctl, which is
available in pre-packaged Trident releases.  You may find all Trident releases and source code
online at https://github.com/NetApp/trident.

To learn more about the release, try:

  $ helm status trident
  $ helm get all trident

```

