### PR TITLE
Adding standard common helm chart values

### DIFF
--- a/helm/trident-operator/templates/deployment.yaml
+++ b/helm/trident-operator/templates/deployment.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+{{- if .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+{{- end }}
   labels:
     app: operator.trident.netapp.io
   name: trident-operator
@@ -15,6 +19,10 @@ spec:
       name: trident-operator
   template:
     metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
       labels:
         app: operator.trident.netapp.io
         name: trident-operator
@@ -22,6 +30,17 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
+      {{- if .Values.nodeSelector }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.server.tolerations }}
+      tolerations:
+{{ toYaml .Values.server.tolerations | indent 8 }}
+      {{- end }}
       serviceAccountName: trident-operator
       containers:
       - command:

--- a/helm/trident-operator/values.yaml
+++ b/helm/trident-operator/values.yaml
@@ -1,3 +1,23 @@
+# Default values for standalone.
+# This is a YAML-formatted file.
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Pod Annotations
+podAnnotations: {}
+
+## Deployment Annotations
+deploymentAnnotations: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
 
 # imageRegistry identifies the registry for the trident-operator, trident, and other images.  Leave empty to accept the default.
 imageRegistry: ""


### PR DESCRIPTION
Signed-off-by: julian3xl <julian3xl@gmail.com>

Helm Chart is a mature packaging system that tries to establish a series of common methodologies so that the deployment of packages in a kubernetes cluster is as consistent as possible. Things like nodeSelector, affinity and so on are values that chart users should be able to choose.