### PR TITLE
Update operator-deploy.rst

### DIFF
--- a/docs/kubernetes/deploying/operator-deploy.rst
+++ b/docs/kubernetes/deploying/operator-deploy.rst
@@ -117,7 +117,7 @@ you have the necessary privileges to.
 
   # Can you launch a pod that uses an image from Docker Hub and can reach your
   # storage system over the pod network?
-  kubectl run -i --tty ping --image=busybox --restart=Never --rm -- \
+  kubectl run -i --tty ping --image=busybox --restart=Never --rm --privileged=true -- \
     ping <management IP>
 
 2: Download & setup the operator


### PR DESCRIPTION
Ping requires `CAP_NET_RAW` permissions in the pod. Running the pod with '--privileged=true' 
will grant CAP_NET_RAW. This maybe runtime dependent but it is required using `cri-o` with an OCI 
compliant runtime.