### PR TITLE
Set memory requests to 0

### DIFF
--- a/cli/k8s_client/yaml_factory.go
+++ b/cli/k8s_client/yaml_factory.go
@@ -453,6 +453,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: '0'
         volumeMounts:
         - name: asup-dir
           mountPath: /asup


### PR DESCRIPTION
Currently there is a memory limit of 1Gi configured for the autosupport container. Because there is no memory request configured for the autosupport container, Kubernetes automatically sets the memory request equal to the memory limit.

This means by default the autosupport container requests 1Gi memory. I understand the need for a limit here, but i think it would be preferable to disable the requests for this container, this can be done by setting it to 0.

Closes #605 