### PR TITLE
Modifying parameters in the last version docs

### DIFF
--- a/docs/kubernetes/operations/tasks/backends/cvs_aws.rst
+++ b/docs/kubernetes/operations/tasks/backends/cvs_aws.rst
@@ -115,7 +115,6 @@ This example shows a backend file that applies the same aspects to all Trident c
         "secretKey": "rR0rUmWXfNioN1KhtHisiSAnoTherboGuskey6pU",
         "proxyURL": "http://proxy-server-hostname/",
         "nfsMountOptions": "nfsvers=3,proto=tcp,timeo=600",
-        "limitVolumeSize": "50Gi",
         "serviceLevel": "premium",
         "defaults": {
             "snapshotDir": "true",
@@ -214,7 +213,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-extreme-extra-protection
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "performance=extreme; protection=extra"
     allowVolumeExpansion: true
@@ -223,7 +222,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-extreme-standard-protection
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "performance=extreme; protection=standard"
     allowVolumeExpansion: true
@@ -232,7 +231,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-premium-extra-protection
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "performance=premium; protection=extra"
     allowVolumeExpansion: true
@@ -241,7 +240,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-premium
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "performance=premium; protection=standard"
     allowVolumeExpansion: true
@@ -250,7 +249,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-standard
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "performance=standard"
     allowVolumeExpansion: true
@@ -259,7 +258,7 @@ The first StorageClass (``cvs-extreme-extra-protection``) will map to the first 
     kind: StorageClass
     metadata:
       name: cvs-extra-protection
-    provisioner: netapp.io/trident
+    provisioner: csi.trident.netapp.io
     parameters:
       selector: "protection=extra"
     allowVolumeExpansion: true


### PR DESCRIPTION
Hello team.

I'm requesting these changes as our customers are getting confusing.

For the StorageClasses: We're not using anymore the provisioner "netapp.io/trident" and needs to be replaced by "csi.trident.netapp.io" in all of them.
For the CVS backend configuration doesn't make sense to have the parameter "limitVolumeSize": "50Gi" since the minimum volume size is 100Gi so using that they will get the error that the size requested is bigger than the one set here.

I really appreciate you take care of this. Thanks a lot !