### PR TITLE
Add --kubeconfig option to tridentctl

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -326,7 +326,7 @@ func discoverInstallationEnvironment() error {
 }
 
 func initClient() (k8sclient.KubernetesClient, error) {
-	clients, err := k8sclient.CreateK8SClients("", "", "")
+	clients, err := k8sclient.CreateK8SClients("", KubeConfigPath, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -269,7 +268,7 @@ func getTridentLogs(logName string) error {
 	}
 
 	// Get logs
-	logBytes, err := exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+	logBytes, err := execKubernetesCLI(logsCommand...).CombinedOutput()
 	if err != nil {
 		logErrors = appendError(logErrors, logBytes)
 	} else {
@@ -292,7 +291,7 @@ func getTridentLogs(logName string) error {
 			}
 
 			// Get logs
-			logBytes, err = exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+			logBytes, err = execKubernetesCLI(logsCommand...).CombinedOutput()
 			if err != nil {
 				logErrors = appendError(logErrors, logBytes)
 			} else {
@@ -337,7 +336,7 @@ func getNodeLogs(logName, nodeName string) error {
 	}
 
 	// Get logs
-	logBytes, err := exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+	logBytes, err := execKubernetesCLI(logsCommand...).CombinedOutput()
 	if err != nil {
 		logErrors = appendError(logErrors, logBytes)
 	} else {
@@ -360,7 +359,7 @@ func getNodeLogs(logName, nodeName string) error {
 			}
 
 			// Get logs
-			logBytes, err = exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+			logBytes, err = execKubernetesCLI(logsCommand...).CombinedOutput()
 			if err != nil {
 				logErrors = appendError(logErrors, logBytes)
 			} else {
@@ -406,7 +405,7 @@ func getAllNodeLogs(logName string) error {
 		}
 
 		// Get logs
-		logBytes, err := exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+		logBytes, err := execKubernetesCLI(logsCommand...).CombinedOutput()
 		if err != nil {
 			logErrors = appendError(logErrors, logBytes)
 		} else {
@@ -429,7 +428,7 @@ func getAllNodeLogs(logName string) error {
 				}
 
 				// Get logs
-				logBytes, err = exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+				logBytes, err = execKubernetesCLI(logsCommand...).CombinedOutput()
 				if err != nil {
 					logErrors = appendError(logErrors, logBytes)
 				} else {
@@ -465,7 +464,7 @@ func getTridentOperatorLogs(logName string) error {
 	}
 
 	// Get logs
-	logBytes, err := exec.Command(KubernetesCLI, logsCommand...).CombinedOutput()
+	logBytes, err := execKubernetesCLI(logsCommand...).CombinedOutput()
 	if err != nil {
 		logErrors = appendError(logErrors, logBytes)
 	} else {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -221,6 +221,13 @@ func discoverJustOperatingMode(_ *cobra.Command) error {
 	return nil
 }
 
+func execKubernetesCLI(args ...string) *exec.Cmd {
+	if KubeConfigPath != "" {
+		args = append([]string{"--kubeconfig", KubeConfigPath}, args...)
+	}
+	return exec.Command(KubernetesCLI, args...)
+}
+
 func discoverKubernetesCLI() error {
 	// Try the OpenShift CLI first
 	_, err := exec.Command(CLIOpenshift, "version").Output()
@@ -247,7 +254,7 @@ func discoverKubernetesCLI() error {
 // getCurrentNamespace returns the default namespace from service account info
 func getCurrentNamespace() (string, error) {
 	// Get current namespace from service account info
-	cmd := exec.Command(KubernetesCLI, "get", "serviceaccount", "default", "-o=json")
+	cmd := execKubernetesCLI("get", "serviceaccount", "default", "-o=json")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return "", err
@@ -289,8 +296,7 @@ func discoverAutosupportCollector() {
 // getTridentPod returns the name of the Trident pod in the specified namespace
 func getTridentPod(namespace, appLabel string) (string, error) {
 	// Get 'trident' pod info
-	cmd := exec.Command(
-		KubernetesCLI,
+	cmd := execKubernetesCLI(
 		"get", "pod",
 		"-n", namespace,
 		"-l", appLabel,
@@ -327,8 +333,7 @@ func getTridentPod(namespace, appLabel string) (string, error) {
 // getTridentOperatorPod returns the name and namespace of the Trident pod
 func getTridentOperatorPod(appLabel string) (string, string, error) {
 	// Get 'trident-operator' pod info
-	cmd := exec.Command(
-		KubernetesCLI,
+	cmd := execKubernetesCLI(
 		"get", "pod",
 		"--all-namespaces",
 		"-l", appLabel,
@@ -366,8 +371,7 @@ func getTridentOperatorPod(appLabel string) (string, string, error) {
 func listTridentSidecars(podName, podNameSpace string) ([]string, error) {
 	// Get 'trident' pod info
 	var sidecarNames []string
-	cmd := exec.Command(
-		KubernetesCLI,
+	cmd := execKubernetesCLI(
 		"get", "pod",
 		podName,
 		"-n", podNameSpace,
@@ -401,8 +405,7 @@ func listTridentSidecars(podName, podNameSpace string) ([]string, error) {
 
 func getTridentNode(nodeName, namespace string) (string, error) {
 	selector := fmt.Sprintf("--field-selector=spec.nodeName=%s", nodeName)
-	cmd := exec.Command(
-		KubernetesCLI,
+	cmd := execKubernetesCLI(
 		"get", "pod",
 		"-n", namespace,
 		"-l", TridentNodeLabel,
@@ -440,8 +443,7 @@ func getTridentNode(nodeName, namespace string) (string, error) {
 func listTridentNodes(namespace string) (map[string]string, error) {
 	// Get trident node pods info
 	tridentNodes := make(map[string]string)
-	cmd := exec.Command(
-		KubernetesCLI,
+	cmd := execKubernetesCLI(
 		"get", "pod",
 		"-n", namespace,
 		"-l", TridentNodeLabel,
@@ -499,11 +501,7 @@ func BaseAutosupportURL() string {
 
 func TunnelCommand(commandArgs []string) {
 	// Build tunnel command to exec command in container
-	execCommand := []string{"exec", TridentPodName, "-n", TridentPodNamespace, "-c", config.ContainerTrident}
-	if KubeConfigPath != "" {
-		execCommand = append(execCommand, "--kubeconfig", KubeConfigPath)
-	}
-	execCommand = append(execCommand, "--")
+	execCommand := []string{"exec", TridentPodName, "-n", TridentPodNamespace, "-c", config.ContainerTrident, "--"}
 	// Build CLI command
 	cliCommand := []string{"tridentctl"}
 	if Debug {
@@ -522,7 +520,7 @@ func TunnelCommand(commandArgs []string) {
 	}
 
 	// Invoke tridentctl inside the Trident pod
-	out, err := exec.Command(KubernetesCLI, execCommand...).CombinedOutput()
+	out, err := execKubernetesCLI(execCommand...).CombinedOutput()
 
 	SetExitCodeFromError(err)
 	if err != nil {
@@ -550,7 +548,7 @@ func TunnelCommandRaw(commandArgs []string) ([]byte, []byte, error) {
 	// Invoke tridentctl inside the Trident pod and get Stdout and Stderr separately in two buffers
 	// Capture the Stdout for the command in outbuff which will later be unmarshalled and
 	// capture the Stderr for the command in os.Stderr
-	cmd := exec.Command(KubernetesCLI, execCommand...)
+	cmd := execKubernetesCLI(execCommand...)
 	var outbuff, stderrBuff bytes.Buffer
 	cmd.Stdout = &outbuff
 	cmd.Stderr = &stderrBuff

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -83,6 +83,7 @@ var (
 	KubernetesCLI       string
 	TridentPodName      string
 	TridentPodNamespace string
+	KubeConfigPath      string
 	ExitCode            int
 
 	Debug                bool
@@ -109,6 +110,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&Server, "server", "s", "", "Address/port of Trident REST interface (127.0.0.1 or [::1] only)")
 	RootCmd.PersistentFlags().StringVarP(&OutputFormat, "output", "o", "", "Output format. One of json|yaml|name|wide|ps (default)")
 	RootCmd.PersistentFlags().StringVarP(&TridentPodNamespace, "namespace", "n", "", "Namespace of Trident deployment")
+	RootCmd.PersistentFlags().StringVarP(&KubeConfigPath, "kubeconfig", "k", "", "Kubernetes config path")
 }
 
 func discoverOperatingMode(_ *cobra.Command) error {
@@ -497,8 +499,11 @@ func BaseAutosupportURL() string {
 
 func TunnelCommand(commandArgs []string) {
 	// Build tunnel command to exec command in container
-	execCommand := []string{"exec", TridentPodName, "-n", TridentPodNamespace, "-c", config.ContainerTrident, "--"}
-
+	execCommand := []string{"exec", TridentPodName, "-n", TridentPodNamespace, "-c", config.ContainerTrident}
+	if KubeConfigPath != "" {
+		execCommand = append(execCommand, "--kubeconfig", KubeConfigPath)
+	}
+	execCommand = append(execCommand, "--")
 	// Build CLI command
 	cliCommand := []string{"tridentctl"}
 	if Debug {


### PR DESCRIPTION
## Change description
This PR will add an optional --kubeconfig argument to specify a kubeconfig file to use, similar to kubectl and oc.


## Project tracking
see https://github.com/NetApp/trident/issues/734)

## Do any added TODOs have an issue in the backlog?
N/A

## Did you add unit tests? Why not?
No, this only adds one optional argument that is no-op when not specified

## Does this code need functional testing?
The changes do not change the main logic of the tridentctl code.
I have tested it using different commands and kubeconfig files and it is working.

## Is a code review walkthrough needed? why or why not?
Probably not needed as the changes are relatively simple and only touch a few files

## Should additional test coverage be executed in addition to pre-merge?
May require adding test that pass a specific kubeconfig file

## Does this code need a note in the changelog?
Yes - same as title of this PR

## Does this code require documentation changes?
Yes - self descript line to be added is sufficient as users are already familiar with the argument from using kubectl and oc

## Additional Information

