### PR TITLE
Allow overriding the namespace of the orchestrator

### DIFF
--- a/helm/trident-operator/templates/_helpers.tpl
+++ b/helm/trident-operator/templates/_helpers.tpl
@@ -187,3 +187,13 @@ Trident image pull policy
 {{- "IfNotPresent" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Trident orchestrator namespace
+*/}}
+{{- define "trident.orchestratorNamespace" -}}
+{{- if .Values.orchestratorNamespace }}
+{{- .Values.orchestratorNamespace }}
+{{- else }}
+{{- .Release.Namespace }}{{- end }}
+{{- end }}

--- a/helm/trident-operator/templates/tridentorchestrator.yaml
+++ b/helm/trident-operator/templates/tridentorchestrator.yaml
@@ -3,7 +3,7 @@ kind: TridentOrchestrator
 metadata:
   name: trident
 spec:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trident.orchestratorNamespace" $ }}
   enableForceDetach: {{ include "trident.enableForceDetach" $ }}
   debug: {{ include "trident.debug" $ }}
   IPv6: {{ include "trident.IPv6" $ }}

--- a/helm/trident-operator/values.yaml
+++ b/helm/trident-operator/values.yaml
@@ -105,5 +105,8 @@ tridentProbePort: ""
 # windows allows Trident to be installed on Windows worker node.
 windows: false
 
+# orchestratorNamespace allows overriding the namespace of the orchestrator
+orchestratorNamespace: ""
+
 # enableForceDetach allows enabling the force detach feature.
 enableForceDetach: false


### PR DESCRIPTION
## Change description
Allow overriding the namespace of the orchestrator if you need it to be deployed to a namespace other than the namespace the operator is deployed in.


## Project tracking
#775 


## Do any added TODOs have an issue in the backlog?
No


## Did you add unit tests? Why not?
No. minor change in helm chart, deploys correctly to private cluster

## Does this code need functional testing?
No.


## Is a code review walkthrough needed? why or why not?
No.

## Should additional test coverage be executed in addition to pre-merge?
No.


## Does this code need a note in the changelog?
Yes. e.g.: Allow overriding the namespace of the orchestrator


## Does this code require documentation changes?
No


## Additional Information

