### PR TITLE
Set namespace in commands in chart notes

### DIFF
--- a/helm/trident-operator/Chart.yaml
+++ b/helm/trident-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trident-operator
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">= 1.21.0-0"
 description: "A Helm chart for deploying NetApp's Trident CSI storage provisioner using the Trident Operator."
 type: application

--- a/helm/trident-operator/templates/NOTES.txt
+++ b/helm/trident-operator/templates/NOTES.txt
@@ -11,5 +11,5 @@ online at {{ .Chart.Home }}.
 
 To learn more about the release, try:
 
-  $ helm status {{ .Release.Name }}
-  $ helm get all {{ .Release.Name }}
+  $ helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
+  $ helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 

This change explicitly sets the namespace in the commands suggested in the chart's NOTES.txt file, which are rendered upon installation.
Before this change, the namespace was not included so the commands would generally not work without modification.

## Did you add unit tests? Why not?

No, this is a trivial change and a change to what basically amounts to documentation, nonetheless.


## Does this code need functional testing?

No, but I ran `helm install foo --dry-run .` to test it first, and it seems to work as intended.

_Note:_ I first had to `kubectl apply -f ./crds/tridentorchestrators.yaml` to be able to run the `helm install` command, even with `--dry-run`. I think there's no way around that, unfortunately.


## Is a code review walkthrough needed? why or why not?

Nah, it's a very straight-forward change imo.

## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->

No.


## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->

No.

## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->

No.

## Additional Information

I've also bumped the chart version.