### PR TITLE
Add option for operator to set resource claims on daemonset containers

### DIFF
--- a/cli/k8s_client/types.go
+++ b/cli/k8s_client/types.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 
+	netappv1 "github.com/netapp/trident/operator/controllers/orchestrator/apis/netapp/v1"
 	versionutils "github.com/netapp/trident/utils/version"
 )
 
@@ -168,27 +169,29 @@ type DeploymentYAMLArguments struct {
 }
 
 type DaemonsetYAMLArguments struct {
-	DaemonsetName        string                `json:"daemonsetName"`
-	TridentImage         string                `json:"tridentImage"`
-	ImageRegistry        string                `json:"imageRegistry"`
-	KubeletDir           string                `json:"kubeletDir"`
-	LogFormat            string                `json:"logFormat"`
-	LogLevel             string                `json:"logLevel"`
-	LogWorkflows         string                `json:"logWorkflows"`
-	LogLayers            string                `json:"logLayers"`
-	ProbePort            string                `json:"probePort"`
-	ImagePullSecrets     []string              `json:"imagePullSecrets"`
-	Labels               map[string]string     `json:"labels"`
-	ControllingCRDetails map[string]string     `json:"controllingCRDetails"`
-	EnableForceDetach    bool                  `json:"enableForceDetach"`
-	DisableAuditLog      bool                  `json:"disableAuditLog"`
-	Debug                bool                  `json:"debug"`
-	Version              *versionutils.Version `json:"version"`
-	HTTPRequestTimeout   string                `json:"httpRequestTimeout"`
-	NodeSelector         map[string]string     `json:"nodeSelector"`
-	Tolerations          []map[string]string   `json:"tolerations"`
-	ServiceAccountName   string                `json:"serviceAccountName"`
-	ImagePullPolicy      string                `json:"imagePullPolicy"`
+	DaemonsetName         string                `json:"daemonsetName"`
+	TridentImage          string                `json:"tridentImage"`
+	ImageRegistry         string                `json:"imageRegistry"`
+	KubeletDir            string                `json:"kubeletDir"`
+	LogFormat             string                `json:"logFormat"`
+	LogLevel              string                `json:"logLevel"`
+	LogWorkflows          string                `json:"logWorkflows"`
+	LogLayers             string                `json:"logLayers"`
+	ProbePort             string                `json:"probePort"`
+	ImagePullSecrets      []string              `json:"imagePullSecrets"`
+	Labels                map[string]string     `json:"labels"`
+	ControllingCRDetails  map[string]string     `json:"controllingCRDetails"`
+	EnableForceDetach     bool                  `json:"enableForceDetach"`
+	DisableAuditLog       bool                  `json:"disableAuditLog"`
+	Debug                 bool                  `json:"debug"`
+	Version               *versionutils.Version `json:"version"`
+	HTTPRequestTimeout    string                `json:"httpRequestTimeout"`
+	NodeSelector          map[string]string     `json:"nodeSelector"`
+	Tolerations           []map[string]string   `json:"tolerations"`
+	TridentResourceSpec   netappv1.ResourceSpec `json:"tridentResourceSpec"`
+	RegistrarResourceSpec netappv1.ResourceSpec `json:"registrarSpec"`
+	ServiceAccountName    string                `json:"serviceAccountName"`
+	ImagePullPolicy       string                `json:"imagePullPolicy"`
 }
 
 type TridentVersionPodYAMLArguments struct {

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/apimachinery v0.27.3 // github.com/kubernetes/apimachinery
 	k8s.io/client-go v0.27.3 // github.com/kubernetes/client-go
 	k8s.io/mount-utils v0.27.3 // github.com/kubernetes/mount-utils
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -132,5 +133,4 @@ require (
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/operator/controllers/orchestrator/apis/netapp/v1/types.go
+++ b/operator/controllers/orchestrator/apis/netapp/v1/types.go
@@ -5,6 +5,7 @@ package v1
 import (
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,35 +34,41 @@ type TridentOrchestratorList struct {
 
 // TridentOrchestratorSpec defines the desired state of TridentOrchestrator
 type TridentOrchestratorSpec struct {
-	EnableForceDetach            bool              `json:"enableForceDetach"`
-	DisableAuditLog              *bool             `json:"disableAuditLog"`
-	Namespace                    string            `json:"namespace"`
-	IPv6                         bool              `json:"IPv6,omitempty"`
-	K8sTimeout                   int               `json:"k8sTimeout,omitempty"`
-	HTTPRequestTimeout           string            `json:"httpRequestTimeout,omitempty"`
-	SilenceAutosupport           bool              `json:"silenceAutosupport,omitempty"`
-	AutosupportImage             string            `json:"autosupportImage,omitempty"`
-	AutosupportProxy             string            `json:"autosupportProxy,omitempty"`
-	AutosupportSerialNumber      string            `json:"autosupportSerialNumber,omitempty"`
-	AutosupportHostname          string            `json:"autosupportHostname,omitempty"`
-	Uninstall                    bool              `json:"uninstall,omitempty"`
-	LogFormat                    string            `json:"logFormat,omitempty"`
-	LogLevel                     string            `json:"logLevel,omitempty"`
-	Debug                        bool              `json:"debug,omitempty"`
-	LogWorkflows                 string            `json:"logWorkflows,omitempty"`
-	LogLayers                    string            `json:"logLayers,omitempty"`
-	ProbePort                    *int64            `json:"probePort,omitempty"`
-	TridentImage                 string            `json:"tridentImage,omitempty"`
-	ImageRegistry                string            `json:"imageRegistry,omitempty"`
-	KubeletDir                   string            `json:"kubeletDir,omitempty"`
-	Wipeout                      []string          `json:"wipeout,omitempty"`
-	ImagePullSecrets             []string          `json:"imagePullSecrets,omitempty"`
-	ControllerPluginNodeSelector map[string]string `json:"controllerPluginNodeSelector,omitempty"`
-	ControllerPluginTolerations  []Toleration      `json:"controllerPluginTolerations,omitempty"`
-	NodePluginNodeSelector       map[string]string `json:"nodePluginNodeSelector,omitempty"`
-	NodePluginTolerations        []Toleration      `json:"nodePluginTolerations,omitempty"`
-	Windows                      bool              `json:"windows,omitempty"`
-	ImagePullPolicy              string            `json:"imagePullPolicy,omitempty"`
+	EnableForceDetach            bool                    `json:"enableForceDetach"`
+	DisableAuditLog              *bool                   `json:"disableAuditLog"`
+	Namespace                    string                  `json:"namespace"`
+	IPv6                         bool                    `json:"IPv6,omitempty"`
+	K8sTimeout                   int                     `json:"k8sTimeout,omitempty"`
+	HTTPRequestTimeout           string                  `json:"httpRequestTimeout,omitempty"`
+	SilenceAutosupport           bool                    `json:"silenceAutosupport,omitempty"`
+	AutosupportImage             string                  `json:"autosupportImage,omitempty"`
+	AutosupportProxy             string                  `json:"autosupportProxy,omitempty"`
+	AutosupportSerialNumber      string                  `json:"autosupportSerialNumber,omitempty"`
+	AutosupportHostname          string                  `json:"autosupportHostname,omitempty"`
+	Uninstall                    bool                    `json:"uninstall,omitempty"`
+	LogFormat                    string                  `json:"logFormat,omitempty"`
+	LogLevel                     string                  `json:"logLevel,omitempty"`
+	Debug                        bool                    `json:"debug,omitempty"`
+	LogWorkflows                 string                  `json:"logWorkflows,omitempty"`
+	LogLayers                    string                  `json:"logLayers,omitempty"`
+	ProbePort                    *int64                  `json:"probePort,omitempty"`
+	TridentImage                 string                  `json:"tridentImage,omitempty"`
+	ImageRegistry                string                  `json:"imageRegistry,omitempty"`
+	KubeletDir                   string                  `json:"kubeletDir,omitempty"`
+	Wipeout                      []string                `json:"wipeout,omitempty"`
+	ImagePullSecrets             []string                `json:"imagePullSecrets,omitempty"`
+	ControllerPluginNodeSelector map[string]string       `json:"controllerPluginNodeSelector,omitempty"`
+	ControllerPluginTolerations  []Toleration            `json:"controllerPluginTolerations,omitempty"`
+	NodePluginNodeSelector       map[string]string       `json:"nodePluginNodeSelector,omitempty"`
+	NodePluginTolerations        []Toleration            `json:"nodePluginTolerations,omitempty"`
+	DsTridentResources           v1.ResourceRequirements `json:"dsTridentResources,omitempty"`
+	DsRegistrarResources         v1.ResourceRequirements `json:"dsRegistrarResources,omitempty"`
+	Windows                      bool                    `json:"windows,omitempty"`
+	ImagePullPolicy              string                  `json:"imagePullPolicy,omitempty"`
+}
+
+type ResourceSpec struct {
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // Toleration
@@ -109,27 +116,29 @@ type TridentOrchestratorStatus struct {
 }
 
 type TridentOrchestratorSpecValues struct {
-	EnableForceDetach       string            `json:"enableForceDetach"`
-	DisableAuditLog         string            `json:"disableAuditLog"`
-	IPv6                    string            `json:"IPv6"`
-	SilenceAutosupport      string            `json:"silenceAutosupport"`
-	AutosupportImage        string            `json:"autosupportImage"`
-	AutosupportProxy        string            `json:"autosupportProxy"`
-	AutosupportSerialNumber string            `json:"autosupportSerialNumber"`
-	AutosupportHostname     string            `json:"autosupportHostname"`
-	K8sTimeout              string            `json:"k8sTimeout"`
-	HTTPRequestTimeout      string            `json:"httpRequestTimeout"`
-	LogFormat               string            `json:"logFormat"`
-	LogLevel                string            `json:"logLevel"`
-	Debug                   string            `json:"debug"`
-	LogWorkflows            string            `json:"logWorkflows"`
-	LogLayers               string            `json:"logLayers"`
-	ProbePort               string            `json:"probePort"`
-	TridentImage            string            `json:"tridentImage"`
-	ImageRegistry           string            `json:"imageRegistry"`
-	KubeletDir              string            `json:"kubeletDir"`
-	ImagePullSecrets        []string          `json:"imagePullSecrets"`
-	NodePluginNodeSelector  map[string]string `json:"nodePluginNodeSelector,omitempty"`
-	NodePluginTolerations   []Toleration      `json:"nodePluginTolerations,omitempty"`
-	ImagePullPolicy         string            `json:"imagePullPolicy"`
+	EnableForceDetach       string                  `json:"enableForceDetach"`
+	DisableAuditLog         string                  `json:"disableAuditLog"`
+	IPv6                    string                  `json:"IPv6"`
+	SilenceAutosupport      string                  `json:"silenceAutosupport"`
+	AutosupportImage        string                  `json:"autosupportImage"`
+	AutosupportProxy        string                  `json:"autosupportProxy"`
+	AutosupportSerialNumber string                  `json:"autosupportSerialNumber"`
+	AutosupportHostname     string                  `json:"autosupportHostname"`
+	K8sTimeout              string                  `json:"k8sTimeout"`
+	HTTPRequestTimeout      string                  `json:"httpRequestTimeout"`
+	LogFormat               string                  `json:"logFormat"`
+	LogLevel                string                  `json:"logLevel"`
+	Debug                   string                  `json:"debug"`
+	LogWorkflows            string                  `json:"logWorkflows"`
+	LogLayers               string                  `json:"logLayers"`
+	ProbePort               string                  `json:"probePort"`
+	TridentImage            string                  `json:"tridentImage"`
+	ImageRegistry           string                  `json:"imageRegistry"`
+	KubeletDir              string                  `json:"kubeletDir"`
+	ImagePullSecrets        []string                `json:"imagePullSecrets"`
+	NodePluginNodeSelector  map[string]string       `json:"nodePluginNodeSelector,omitempty"`
+	NodePluginTolerations   []Toleration            `json:"nodePluginTolerations,omitempty"`
+	DsRegistrarResources    v1.ResourceRequirements `json:"dsRegistrarResources,omitempty"`
+	DsTridentResources      v1.ResourceRequirements `json:"dsTridentResources,omitempty"`
+	ImagePullPolicy         string                  `json:"imagePullPolicy"`
 }

--- a/operator/controllers/orchestrator/installer/installer.go
+++ b/operator/controllers/orchestrator/installer/installer.go
@@ -86,6 +86,8 @@ var (
 	controllerPluginTolerations  []netappv1.Toleration
 	nodePluginNodeSelector       map[string]string
 	nodePluginTolerations        []netappv1.Toleration
+	tridentResourceSpec          netappv1.ResourceSpec
+	registrarResourceSpec        netappv1.ResourceSpec
 
 	CRDnames = []string{
 		ActionMirrorUpdateCRDName,
@@ -373,6 +375,8 @@ func (i *Installer) setInstallationParams(
 	appLabel = TridentCSILabel
 	appLabelKey = TridentCSILabelKey
 	appLabelValue = TridentCSILabelValue
+	tridentResourceSpec = netappv1.ResourceSpec{Resources: cr.Spec.DsTridentResources}
+	registrarResourceSpec = netappv1.ResourceSpec{Resources: cr.Spec.DsRegistrarResources}
 
 	if cr.Spec.ControllerPluginNodeSelector != nil {
 		controllerPluginNodeSelector = cr.Spec.ControllerPluginNodeSelector
@@ -610,6 +614,8 @@ func (i *Installer) InstallOrPatchTrident(
 		ImagePullSecrets:        imagePullSecrets,
 		NodePluginNodeSelector:  nodePluginNodeSelector,
 		NodePluginTolerations:   nodePluginTolerations,
+		DsRegistrarResources:    registrarResourceSpec.Resources,
+		DsTridentResources:      tridentResourceSpec.Resources,
 		ImagePullPolicy:         imagePullPolicy,
 	}
 
@@ -1458,27 +1464,29 @@ func (i *Installer) createOrPatchTridentDaemonSet(
 	}
 
 	daemonSetArgs := &k8sclient.DaemonsetYAMLArguments{
-		DaemonsetName:        getDaemonSetName(isWindows),
-		TridentImage:         tridentImage,
-		ImageRegistry:        imageRegistry,
-		KubeletDir:           kubeletDir,
-		LogFormat:            logFormat,
-		DisableAuditLog:      disableAuditLog,
-		Debug:                debug,
-		LogLevel:             determineLogLevel(),
-		LogWorkflows:         logWorkflows,
-		LogLayers:            logLayers,
-		ProbePort:            probePort,
-		ImagePullSecrets:     imagePullSecrets,
-		Labels:               labels,
-		ControllingCRDetails: controllingCRDetails,
-		EnableForceDetach:    enableForceDetach,
-		Version:              i.client.ServerVersion(),
-		HTTPRequestTimeout:   httpTimeout,
-		NodeSelector:         nodePluginNodeSelector,
-		Tolerations:          tolerations,
-		ServiceAccountName:   serviceAccountName,
-		ImagePullPolicy:      imagePullPolicy,
+		DaemonsetName:         getDaemonSetName(isWindows),
+		TridentImage:          tridentImage,
+		ImageRegistry:         imageRegistry,
+		KubeletDir:            kubeletDir,
+		LogFormat:             logFormat,
+		DisableAuditLog:       disableAuditLog,
+		Debug:                 debug,
+		LogLevel:              determineLogLevel(),
+		LogWorkflows:          logWorkflows,
+		LogLayers:             logLayers,
+		ProbePort:             probePort,
+		ImagePullSecrets:      imagePullSecrets,
+		Labels:                labels,
+		ControllingCRDetails:  controllingCRDetails,
+		EnableForceDetach:     enableForceDetach,
+		Version:               i.client.ServerVersion(),
+		HTTPRequestTimeout:    httpTimeout,
+		NodeSelector:          nodePluginNodeSelector,
+		RegistrarResourceSpec: registrarResourceSpec,
+		TridentResourceSpec:   tridentResourceSpec,
+		Tolerations:           tolerations,
+		ServiceAccountName:    serviceAccountName,
+		ImagePullPolicy:       imagePullPolicy,
 	}
 
 	var newDaemonSetYAML string


### PR DESCRIPTION
## Change description
**Add option for operator to set resource claims on daemonset containers**

The operator installation of trident currently does not allow setting resource requests and limits for the daemonset containers. With this change the option is added through the TridentOrchestrator crd to set specific resource requests and limits. If no resource requests or limits are set, the current default values are respected.

## Project tracking
N/A

## Do any added TODOs have an issue in the backlog?
No

## Did you add unit tests? Why not?
Added unit tests for the construction of the resource yaml fields.

## Does this code need functional testing?
No

## Is a code review walkthrough needed? why or why not?
I hope the MR is quite straight forward but I'm open for a walkthrough if it helps to get this MR through.

## Should additional test coverage be executed in addition to pre-merge?
No

## Does this code need a note in the changelog?
Yes, two extra fields have been added to the tridentorchestrator crd:

```yaml
apiVersion: trident.netapp.io/v1
kind: TridentOrchestrator
spec:
  dsRegistrarResources: {}
  dsTridentResources: {}
```

The old default values are being respected when these fields are not set. In case they are set, they will configure the trident daemonset according to the [corev1 resourceRequirements](https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements) field.

## Does this code require documentation changes?
No


## Additional Information
Currently we're using the trident operator install on a cluster with about ~90 nodes. The `trident-node-linux` daemonset that the operator generates does not have any resources requests / limits specified. Because of this the pods inherit the resources requests / limits that the are being set by the limitrange object from our rancher setup. This results both in way too many resources being claimed. With this MR we hope to get some more control over the daemonset this is being generated by the operator.
