### PR TITLE
Use dmsetup remove to ensure multipath device

### DIFF
--- a/chwrap/make-tarball.sh
+++ b/chwrap/make-tarball.sh
@@ -5,7 +5,7 @@
 PREFIX=$(mktemp -d)
 mkdir -p $PREFIX/netapp
 cp "$1" $PREFIX/netapp/chwrap
-for BIN in apt blkid blockdev cat cryptsetup dd df dnf docker e2fsck free fsck.ext3 fsck.ext4 iscsiadm losetup ls lsblk lsscsi \
+for BIN in apt blkid blockdev cat cryptsetup dd df dmsetup dnf docker e2fsck free fsck.ext3 fsck.ext4 iscsiadm losetup ls lsblk lsscsi \
 mkdir mkfs.ext3 mkfs.ext4 mkfs.xfs mount mount.nfs mount.nfs4 mpathconf multipath multipathd pgrep resize2fs rmdir \
 rpcinfo stat systemctl umount xfs_growfs yum ; do
   ln -s chwrap $PREFIX/netapp/$BIN


### PR DESCRIPTION
Use dmsetup remove to ensure multipath device mapping is flushed in case multipath -f fails.

