### PR TITLE
Allow users to specify different image registry for helm chart resources and TridentOrchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 **Enhancements:**
 
 - iSCSI self-healing will now initiate SCSI scans by exact LUN ID if deprecated igroups are in use (Issue [#883](https://github.com/NetApp/trident/issues/883)).
-- **Kubernetes**: Trident DaemonSet will now clean zombie mounts and residual tracking files at startup.
+- **Kubernetes:** Trident DaemonSet will now clean zombie mounts and residual tracking files at startup.
+- **Kubernetes:** Added `orchestratorImageRegistry` and `enableTridentOrchestrator` attributes to the Helm chart to enable users to specify different imageRegistries for this helm chart and TridentOrchestrator resource.
 
 ## v24.02.0
 

--- a/helm/trident-operator/Chart.yaml
+++ b/helm/trident-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trident-operator
-version: 101.2405.0 # Some services require a semver here: "100.<CalVer>"
+version: 100.2405.0 # Some services require a semver here: "100.<CalVer>"
 kubeVersion: ">= 1.24.0-0"
 description: "A Helm chart for deploying NetApp's Trident CSI storage provisioner using the Trident Operator."
 type: application

--- a/helm/trident-operator/Chart.yaml
+++ b/helm/trident-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: trident-operator
-version: 100.2405.0 # Some services require a semver here: "100.<CalVer>"
+version: 101.2405.0 # Some services require a semver here: "100.<CalVer>"
 kubeVersion: ">= 1.24.0-0"
 description: "A Helm chart for deploying NetApp's Trident CSI storage provisioner using the Trident Operator."
 type: application

--- a/helm/trident-operator/templates/tridentorchestrator.yaml
+++ b/helm/trident-operator/templates/tridentorchestrator.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.enableTridentOrchestrator }}
 apiVersion: trident.netapp.io/v1
 kind: TridentOrchestrator
 metadata:
@@ -24,8 +25,8 @@ spec:
   logLayers: {{ include "trident.logLayers" $ }}
   probePort: {{ include "trident.probePort" $ }}
   tridentImage: {{ include "trident.image" $ }}
-  {{- if .Values.imageRegistry }}
-  imageRegistry: {{ .Values.imageRegistry }}
+  {{- if .Values.orchestratorImageRegistry }}
+  imageRegistry: {{ .Values.orchestratorImageRegistry }}
   {{- end }}
   kubeletDir: {{ .Values.kubeletDir }}
   {{- with .Values.imagePullSecrets }}
@@ -68,3 +69,4 @@ spec:
   acpImage: {{ .Values.acpImage }}
   iscsiSelfHealingInterval: {{ .Values.iscsiSelfHealingInterval }}
   iscsiSelfHealingWaitTime: {{ .Values.iscsiSelfHealingWaitTime }}
+{{ end }}

--- a/helm/trident-operator/values.yaml
+++ b/helm/trident-operator/values.yaml
@@ -36,6 +36,11 @@ affinity: {}
 # imageRegistry identifies the registry for the trident-operator, trident, and other images.  Leave empty to accept the default.
 imageRegistry: ""
 
+# use to enable/disable deployment of trident orchestrator
+enableTridentOrchestrator: true
+# orchestratorImageRegistry is used in the TridentOrchestrator for imageRegistry parameter
+orchestratorImageRegistry: null
+
 # imagePullPolicy sets the image pull policy for the trident-operator.
 imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 
Allow users to specify different image registry for helm chart resources and TridentOrchestrator

## Project tracking
<!-- What is the Jira Issue URL for this PR? -->
None

## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->
Nope

## Did you add unit tests? Why not?
Not necessary

## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->
Nope

## Is a code review walkthrough needed? why or why not?
Not sure.

## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->
No

## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
Yes.

## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
Not sure

## Additional Information

This PR allows setting different image registry for helm deployment images and TridentOrchestrator.