### PR TITLE
permit specifying trident-operator resources

### DIFF
--- a/helm/trident-operator/templates/deployment.yaml
+++ b/helm/trident-operator/templates/deployment.yaml
@@ -68,12 +68,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: trident-operator
         resources:
-          requests:
-            cpu: "10m"
-            memory: "40Mi"
-          limits:
-            cpu: "20m"
-            memory: "80Mi"
+          {{- toYaml .Values.operatorResources | nindent 10 }}
       {{- if and (eq .Values.cloudProvider "Azure") (eq .Values.cloudIdentity "") }}
       volumes:
       - name: azure-cred

--- a/helm/trident-operator/values.yaml
+++ b/helm/trident-operator/values.yaml
@@ -74,6 +74,15 @@ operatorImage: ""
 # operatorImageTag allows overriding the tag of the trident-operator image.
 operatorImageTag: ""
 
+# operatorResources permits configuring the trident-operator resources.
+operatorResources:
+  requests:
+    cpu: "10m"
+    memory: "40Mi"
+  limits:
+    cpu: "20m"
+    memory: "80Mi"
+
 
 # tridentIPv6 allows enabling Trident to work in IPv6 clusters.
 tridentIPv6: false


### PR DESCRIPTION
closes https://github.com/NetApp/trident/issues/927

## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 
Permit specifying the resources of the trident-operator deployment

## Did you add unit tests? Why not?
No, minor helm chart

## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->
No, this just moves a configuration to the `.Values`

## Is a code review walkthrough needed? why or why not?
No

## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
trident operator helm chart: permit specifying trident-operator resources

## Additional Information

