### PR TITLE
Increased timeout to 5 minutes

### DIFF
--- a/operator/controllers/orchestrator/installer/installer.go
+++ b/operator/controllers/orchestrator/installer/installer.go
@@ -1797,7 +1797,7 @@ func (i *Installer) getTridentVersionYAML(imageName string, controllingCRDetails
 	}
 
 	// Wait for Trident version pod to provide information
-	timeout := 30 * time.Second
+	timeout := 300 * time.Second
 	output, err := i.client.ExecPodForVersionInformation(podName, tridentVersionCommand, timeout)
 	if err != nil {
 		errMessage := fmt.Sprintf("failed to exec Trident version pod '%s' (image: '%s') for the information; err: %v",


### PR DESCRIPTION
The operator creates a POD "transient-trident-version-pod" and executes a command ("/bin/tridentctl version --client -o yaml") inside it. In "ExecPodForVersionInformation" in k8s_client.go it tries to execute this command several times, with a backoff mechanism. However, the hard limit is 30s. The version extract command must be executed within 30s, otherwise the operator will delete the POD again.

We have a slow setup where it takes longer to startup a POD. Unfortunately longer than 30s. The result is that the operator kills the POD (which is still starting up) and retries again to run a new POD. This happens indefinitely until the version info could be extracted within 30s.

The proposal is to increase this timeout to 5 minutes (this PR). Such that slower environments have more time to spin up PODs. Note that as soon as the version info is extracted, the operator continues. i.e. fast environments are not affected by this timeout increase.

