### PR TITLE
Close #992: Add tag support for .Values.tridentAutosupportImage

### DIFF
--- a/helm/trident-operator/templates/_helpers.tpl
+++ b/helm/trident-operator/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Trident operator image
 */}}
 {{- define "trident-operator.image" -}}
 {{- if .Values.operatorImage }}
-{{- .Values.operatorImage }}
+{{- .Values.operatorImage }}:{{ .Values.operatorImageTag | default .Chart.AppVersion }}
 {{- else if .Values.imageRegistry }}
 {{- .Values.imageRegistry }}/trident-operator:{{ .Values.operatorImageTag | default .Chart.AppVersion }}
 {{- else }}
@@ -114,7 +114,7 @@ Trident AutoSupport image
 */}}
 {{- define "trident.autosupportImage" -}}
 {{- if .Values.tridentAutosupportImage }}
-{{- .Values.tridentAutosupportImage }}
+{{- .Values.tridentAutosupportImage }}:{{ .Values.tridentAutosupportImageTag | default .Chart.AppVersion | trunc 5}}
 {{- else if .Values.imageRegistry }}
 {{- .Values.imageRegistry }}/trident-autosupport:{{ .Values.tridentAutosupportImageTag | default .Chart.AppVersion | trunc 5}}
 {{- else }}
@@ -188,7 +188,7 @@ Trident image
 */}}
 {{- define "trident.image" -}}
 {{- if .Values.tridentImage }}
-{{- .Values.tridentImage }}
+{{- .Values.tridentImage }}:{{ .Values.tridentImageTag | default .Chart.AppVersion }}
 {{- else if .Values.imageRegistry }}
 {{- .Values.imageRegistry }}/trident:{{ .Values.tridentImageTag | default .Chart.AppVersion }}
 {{- else }}


### PR DESCRIPTION
## Change description
Close [#992](https://github.com/NetApp/trident/issues/992): Add tag support for .Values.tridentAutosupportImage, .Values.operatorImage, .Values.tridentImage


