### PR TITLE
Parameterise Trident Operator k8s resources

### DIFF
--- a/helm/trident-operator/templates/deployment.yaml
+++ b/helm/trident-operator/templates/deployment.yaml
@@ -71,11 +71,7 @@ spec:
         name: trident-operator
         resources:
           requests:
-            cpu: "10m"
-            memory: "40Mi"
-          limits:
-            cpu: "20m"
-            memory: "80Mi"
+{{ toYaml .Values.resources | indent 10 }}
       {{- if and (eq .Values.cloudProvider "Azure") (eq .Values.cloudIdentity "") }}
       volumes:
       - name: azure-cred

--- a/helm/trident-operator/values.yaml
+++ b/helm/trident-operator/values.yaml
@@ -15,6 +15,15 @@ deploymentAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+resources:
+  requests:
+    cpu: "10m"
+    memory: "40Mi"
+  limits:
+    cpu: "20m"
+    memory: "80Mi"
+
+
 ## Affinity for pod assignment
 ## The following affinity configuration ensures that the Trident operator will only be scheduled on nodes with the specified architecture and OS, Hence, do not modify this section. To add custom affinity rules, please append your content to this configuration as needed
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 
We've observed CPU throttling happening to the trident-operator pod with the hardcoded CPU/MEM resources. Hence I've moved the harcoded resources to the default values , which will allow parameterisation of the resoures in case someone wants to.

## Project tracking
<!-- What is the Jira Issue URL for this PR? -->
N/A

## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->
N/A

## Did you add unit tests? Why not?
N/A

## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->
N/A

## Is a code review walkthrough needed? why or why not?
Yes, but as I'm an external developer, not sure who I'd ask

## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->
Don't think so as helm templates fine

## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
No

## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
No

## Additional Information

