### PR TITLE
Fix typos inside TestPopulateConfigurationDefaults_AllSet test

### DIFF
--- a/storage_drivers/gcp/gcp_gcnv_test.go
+++ b/storage_drivers/gcp/gcp_gcnv_test.go
@@ -893,6 +893,7 @@ func TestPopulateConfigurationDefaults_AllSet(t *testing.T) {
 		},
 		NFSMountOptions:     "nfsvers=4.1",
 		VolumeCreateTimeout: "30",
+		NASType:             "smb",
 		GCNVNASStorageDriverPool: drivers.GCNVNASStorageDriverPool{
 			GCNVNASStorageDriverConfigDefaults: drivers.GCNVNASStorageDriverConfigDefaults{
 				CommonStorageDriverConfigDefaults: drivers.CommonStorageDriverConfigDefaults{
@@ -905,7 +906,6 @@ func TestPopulateConfigurationDefaults_AllSet(t *testing.T) {
 			},
 			StorageClass: "software",
 			ServiceLevel: "premium",
-			NASType:      "smb",
 		},
 	}
 
@@ -920,13 +920,13 @@ func TestPopulateConfigurationDefaults_AllSet(t *testing.T) {
 	assert.Equal(t, "premium", driver.Config.ServiceLevel, "service level mismatch")
 	assert.Equal(t, "software", driver.Config.StorageClass, "storage class mismatch")
 	assert.Equal(t, "nfsvers=4.1", driver.Config.NFSMountOptions, "NFS mount options mismatch")
-	assert.Equal(t, "30", driver.Config.VolumeCreateTimeout, "NFS mount options mismatch")
+	assert.Equal(t, "30", driver.Config.VolumeCreateTimeout, "volume create timeout mismatch")
 	assert.Equal(t, "true", driver.Config.SnapshotDir, "snapshot dir mismatch")
 	assert.Equal(t, "1456898458", driver.Config.SnapshotReserve, "snapshot reserve mismatch")
 	assert.Equal(t, "0700", driver.Config.UnixPermissions, "unix permissions mismatch")
 	assert.Equal(t, "123456789000", driver.Config.LimitVolumeSize, "limit volume size mismatch")
 	assert.Equal(t, "1.1.1.1/32", driver.Config.ExportRule, "export rule mismatch")
-	assert.Equal(t, sa.NFS, driver.Config.NASType, "NAS type mismatch")
+	assert.Equal(t, sa.SMB, driver.Config.NASType, "NAS type mismatch")
 }
 
 func TestPopulateConfigurationDefaults_InvalidSnapshotDir(t *testing.T) {


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 
Fix typos inside TestPopulateConfigurationDefaults_AllSet test.

## Project tracking
<!-- What is the Jira Issue URL for this PR? -->
N/A


## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->
N/A

## Did you add unit tests? Why not? 
N/A


## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->
N/A

## Is a code review walkthrough needed? why or why not?
Yes, I'm an external developer, not sure who to ask for review.


## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->
Don't seem to be so.


## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
No


## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->
No


## Additional Information
For `assert.Equal(t, sa.SMB, driver.Config.NASType, "NAS type mismatch")` update I assume that what was expected to be tested was setting `NASType: "smb",`.