### PR TITLE
Fix backend configuration example

### DIFF
--- a/trident-installer/sample-input/backends-samples/gcnv/backend-gcnv.yaml
+++ b/trident-installer/sample-input/backends-samples/gcnv/backend-gcnv.yaml
@@ -46,7 +46,8 @@ spec:
   network: gcnv-network
   location: us-west2
   serviceLevel: Premium
-  storagePool: pool-premium1
+  storagePools:
+    - pool-premium1
   apiKey:
     type: service_account
     project_id: my-gcp-project


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 

NetApp [Google Cloud NetApp Volumes backend configuration options and examples ](https://docs.netapp.com/us-en/trident/trident-use/gcnv-examples.html#backend-configuration-options) refer to the use of `storagePools` whereas the code example [here](https://github.com/NetApp/trident/blob/master/trident-installer/sample-input/backends-samples/gcnv/backend-gcnv.yaml) refers to `storagePool`.

I assume that this should be an array, which works in my configuration.

I was alerted to this as I could see this field was being ignored in my configuration (which was based on the example provided here).

⚠️ There may be other references that may need adapted. I can only vouch for the GCNV `TridentBackendConfig`

## Project tracking
<!-- What is the Jira Issue URL for this PR? -->


## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->


## Did you add unit tests? Why not?


## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->


## Is a code review walkthrough needed? why or why not?


## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->


## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->


## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->


## Additional Information
Ref: Issue [1099](https://github.com/NetApp/trident/issues/1099)
