### PR TITLE
bind on ::1 for linux and 127.0.0.1 for windows for the probe

### DIFF
--- a/cli/k8s_client/yaml_factory.go
+++ b/cli/k8s_client/yaml_factory.go
@@ -1131,6 +1131,7 @@ spec:
         - "--disable_audit_log={DISABLE_AUDIT_LOG}"
         - "--http_request_timeout={HTTP_REQUEST_TIMEOUT}"
         - "--https_rest"
+        - "--https_address=[::1]"
         - "--https_port={PROBE_PORT}"
         - "--enable_force_detach={FORCE_DETACH_BOOL}"
         - "--iscsi_self_healing_interval={ISCSI_SELF_HEALING_INTERVAL}"
@@ -1138,6 +1139,7 @@ spec:
         {DEBUG}
         startupProbe:
           httpGet:
+            host: localhost
             path: /liveness
             scheme: HTTPS
             port: {PROBE_PORT}
@@ -1146,6 +1148,7 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
+            host: localhost
             path: /liveness
             scheme: HTTPS
             port: {PROBE_PORT}
@@ -1154,6 +1157,7 @@ spec:
           periodSeconds: 10
         readinessProbe:
           httpGet:
+            host: localhost
             path: /readiness
             scheme: HTTPS
             port: {PROBE_PORT}
@@ -1328,6 +1332,7 @@ spec:
         - "--disable_audit_log={DISABLE_AUDIT_LOG}"
         - "--http_request_timeout={HTTP_REQUEST_TIMEOUT}"
         - "--https_rest"
+        - "--https_address=127.0.0.1"
         - "--https_port={PROBE_PORT}"
         {DEBUG}
         # Windows requires named ports for it to actually bind
@@ -1337,6 +1342,7 @@ spec:
             protocol: TCP
         startupProbe:
           httpGet:
+            host: localhost
             path: /liveness
             scheme: HTTPS
             port: healthz
@@ -1345,6 +1351,7 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
+            host: localhost
             path: /liveness
             scheme: HTTPS
             port: healthz
@@ -1353,6 +1360,7 @@ spec:
           periodSeconds: 10
         readinessProbe:
           httpGet:
+            host: localhost
             path: /readiness
             scheme: HTTPS
             port: healthz


### PR DESCRIPTION
## Change description

I am updating the bind-address for the probePort of the `DaemonSet` from `::` to be `::1` for linux and `127.0.0.1` for windows.
This secures the port from being accidentally exposed on kube-proxy Services and additional Network Interfaces which are not managed by K8s NetworkPolicy.

## Project tracking

* #1044 

## Do any added TODOs have an issue in the backlog?

* #1044 

## Did you add unit tests? Why not?

I don't added a Unit-Test as it does not change code but only deployment behaviour.


## Does this code need functional testing?

Yeah It would need to check if the basic installation still works of the DaemonSet in Windows and Linux clusters.

## Is a code review walkthrough needed? why or why not?

Not really.

## Should additional test coverage be executed in addition to pre-merge?

No

## Does this code need a note in the changelog?

Yes, as it binds the `healthz` port to localhost instead of all available IP addresses.

## Does this code require documentation changes?

No, as it does not add any configuration parameter.

## Additional Information

