### PR TITLE
Improvement of autoExportPolicy functionality with CustomExtraExportCIDRs to support clusters behind a SNAT.

### DIFF
--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -133,6 +133,7 @@ type OntapStorageDriverConfig struct {
 	DenyNewVolumePools               string     `json:"denyNewVolumePools"`
 	AutoExportPolicy                 bool       `json:"autoExportPolicy"`
 	AutoExportCIDRs                  []string   `json:"autoExportCIDRs"`
+	CustomExtraExportCIDRs			 []string   `json:"customExtraExportCIDRs"`
 	OntapStorageDriverPool
 	Storage                   []OntapStorageDriverPool `json:"storage"`
 	UseCHAP                   bool                     `json:"useCHAP"`

--- a/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-advanced.yaml
+++ b/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-advanced.yaml
@@ -23,6 +23,9 @@ spec:
   limitAggregateUsage: 80%
   limitVolumeSize: 50Gi
   nfsMountOptions: nfsvers=4
+  useRest: true
+  # customExtraExportCIDRs:
+  # - 192.168.0.0/24
   defaults:
     spaceReserve: volume
     exportPolicy: myk8scluster

--- a/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-autoexport.yaml
+++ b/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-autoexport.yaml
@@ -20,6 +20,9 @@ spec:
   svm: trident_svm
   autoExportCIDRs:
   - 192.168.0.0/24
+  # customExtraExportCIDRs:
+  # - 192.168.0.0/24
   autoExportPolicy: true
+  # useRest: true
   credentials: 
     name: backend-tbc-ontap-nas-autoexport-secret

--- a/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-virtual-pools.yaml
+++ b/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas-virtual-pools.yaml
@@ -17,6 +17,7 @@ spec:
   managementLIF: 10.0.0.1
   dataLIF: 10.0.0.2
   backendName: tbc-ontap-nas-virtual-pools
+  useRest: true
   svm: trident_svm
   credentials: 
     name: backend-tbc-ontap-nas-virtual-pools-secret

--- a/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas.yaml
+++ b/trident-installer/sample-input/backends-samples/ontap-nas/backend-tbc-ontap-nas.yaml
@@ -18,5 +18,8 @@ spec:
   dataLIF: 10.0.0.2
   backendName: tbc-ontap-nas
   svm: trident_svm
+  # useRest: true
+  # customExtraExportCIDRs:
+  # - 192.168.0.0/24
   credentials: 
     name: backend-tbc-ontap-nas-secret


### PR DESCRIPTION
## Change description
Improvement of `autoExportPolicy` to be able to add custom IPs/networks to export policies using a variable in `TridentBackendConfig` named `CustomExtraExportCIDRs`

## Project tracking
N/A

## Do any added TODOs have an issue in the backlog?
N/A

## Did you add unit tests? Why not?
No, I can't test it in my environment.

## Does this code need functional testing?
Yes, someone from netapp please implement proper testing.

## Is a code review walkthrough needed? why or why not?
Yes, not an expert in netapp trident.

## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->


## Does this code need a note in the changelog?
Yes

## Does this code require documentation changes?
Yes

## Additional Information
Related Issue: https://github.com/NetApp/trident/issues/1048 
