### PR TITLE
Support for the ONTAP volume "-is-preserve-unlink-enabled" flag with the ontap-nas backend

### DIFF
--- a/frontend/common/volumes.go
+++ b/frontend/common/volumes.go
@@ -138,6 +138,17 @@ func GetVolumeConfig(
 		snapshotDir = snapDirFormatted
 	}
 
+	// If preserveUnlink is provided, ensure it is lower case
+	preserveUnlink := collection.GetV(opts, "preserveUnlink", "")
+	if preserveUnlink != "" {
+		preserveUnlinkFormatted, err := convert.ToFormattedBool(preserveUnlink)
+		if err != nil {
+			Logc(ctx).WithError(err).Errorf("Invalid boolean value for preserveUnlink: %v.", preserveUnlink)
+			return nil, err
+		}
+		preserveUnlink = preserveUnlinkFormatted
+	}
+
 	cfg := &storage.VolumeConfig{
 		Name:                name,
 		Size:                fmt.Sprintf("%d", sizeBytes),
@@ -150,6 +161,7 @@ func GetVolumeConfig(
 		SplitOnClone:        collection.GetV(opts, "splitOnClone", ""),
 		SnapshotPolicy:      collection.GetV(opts, "snapshotPolicy", ""),
 		SnapshotReserve:     collection.GetV(opts, "snapshotReserve", ""),
+		PreserveUnlink:      preserveUnlink,
 		SnapshotDir:         snapshotDir,
 		ExportPolicy:        collection.GetV(opts, "exportPolicy", ""),
 		UnixPermissions:     collection.GetV(opts, "unixPermissions", ""),

--- a/frontend/csi/controller_helpers/kubernetes/config.go
+++ b/frontend/csi/controller_helpers/kubernetes/config.go
@@ -49,6 +49,7 @@ const (
 	AnnSnapshotPolicy           = prefix + "/snapshotPolicy"
 	AnnSnapshotReserve          = prefix + "/snapshotReserve"
 	AnnSnapshotDir              = prefix + "/snapshotDirectory"
+	AnnPreserveUnlink           = prefix + "/preserveUnlink"
 	AnnUnixPermissions          = prefix + "/unixPermissions"
 	AnnExportPolicy             = prefix + "/exportPolicy"
 	AnnBlockSize                = prefix + "/blockSize"

--- a/frontend/csi/controller_helpers/kubernetes/helper.go
+++ b/frontend/csi/controller_helpers/kubernetes/helper.go
@@ -841,6 +841,16 @@ func getVolumeConfig(
 		snapshotDirAnn = snapDirFormatted
 	}
 
+	// If preserveUnlink annotation is provided, ensure it is lower case
+	preserveUnlinkAnn := getAnnotation(annotations, AnnPreserveUnlink)
+	if preserveUnlinkAnn != "" {
+		preserveUnlinkFormatted, err := convert.ToFormattedBool(preserveUnlinkAnn)
+		if err != nil {
+			Logc(ctx).WithError(err).Errorf("Invalid boolean value for preserveUnlink annotation: %v.", preserveUnlinkAnn)
+		}
+		preserveUnlinkAnn = preserveUnlinkFormatted
+	}
+
 	if getAnnotation(annotations, AnnReadOnlyClone) == "" {
 		annotations[AnnReadOnlyClone] = "false"
 	}
@@ -886,6 +896,7 @@ func getVolumeConfig(
 		SnapshotPolicy:      getAnnotation(annotations, AnnSnapshotPolicy),
 		SnapshotReserve:     getAnnotation(annotations, AnnSnapshotReserve),
 		SnapshotDir:         snapshotDirAnn,
+		PreserveUnlink:      preserveUnlinkAnn,
 		ExportPolicy:        getAnnotation(annotations, AnnExportPolicy),
 		UnixPermissions:     getAnnotation(annotations, AnnUnixPermissions),
 		StorageClass:        storageClass.Name,

--- a/storage/volume.go
+++ b/storage/volume.go
@@ -24,6 +24,7 @@ type VolumeConfig struct {
 	SecurityStyle               string                  `json:"securityStyle"`
 	SnapshotPolicy              string                  `json:"snapshotPolicy,omitempty"`
 	SnapshotReserve             string                  `json:"snapshotReserve,omitempty"`
+	PreserveUnlink              string                  `json:"preserveUnlink,omitempty"`
 	SnapshotDir                 string                  `json:"snapshotDirectory,omitempty"`
 	ExportPolicy                string                  `json:"exportPolicy,omitempty"`
 	UnixPermissions             string                  `json:"unixPermissions,omitempty"`

--- a/storage_drivers/ontap/api/abstraction.go
+++ b/storage_drivers/ontap/api/abstraction.go
@@ -233,6 +233,7 @@ type OntapAPI interface {
 	) (string, error)
 	VolumeRecoveryQueuePurge(ctx context.Context, recoveryQueueVolumeName string) error
 	VolumeRecoveryQueueGetName(ctx context.Context, name string) (string, error)
+	PreserveUnlinkSet(ctx context.Context, volumeName string) error
 	SMBShareCreate(ctx context.Context, shareName, path string) error
 	SMBShareExists(ctx context.Context, shareName string) (bool, error)
 	SMBShareDestroy(ctx context.Context, shareName string) error

--- a/storage_drivers/ontap/api/abstraction_rest.go
+++ b/storage_drivers/ontap/api/abstraction_rest.go
@@ -220,6 +220,14 @@ func (d OntapAPIREST) VolumeRecoveryQueueGetName(ctx context.Context, name strin
 	return recoveryQueueVolumeName, nil
 }
 
+func (d OntapAPIREST) PreserveUnlinkSet(ctx context.Context, volumeName string) error {
+	preserveUnlinkErr := d.api.PreserveUnlinkSet(ctx, volumeName)
+	if preserveUnlinkErr != nil {
+		return fmt.Errorf("error setting preserveUnlink %v: %v", volumeName, preserveUnlinkErr)
+	}
+	return nil
+}
+
 func (d OntapAPIREST) VolumeInfo(ctx context.Context, name string) (*Volume, error) {
 	fields := []string{
 		"type", "size", "comment", "aggregates", "nas", "guarantee",

--- a/storage_drivers/ontap/api/abstraction_zapi.go
+++ b/storage_drivers/ontap/api/abstraction_zapi.go
@@ -125,6 +125,12 @@ func (d OntapAPIZAPI) VolumeDestroy(ctx context.Context, name string, force, ski
 	return nil
 }
 
+// The -is-preserve-unlink-enabled flag is only supported with newer ONTAP versions that use REST.
+func (d OntapAPIZAPI) PreserveUnlinkSet(ctx context.Context, volumeName string) error {
+	Logc(ctx).WithField("volume", volumeName).Warn("preserveUnlink cannot be set with ZAPI.")
+	return nil
+}
+
 func (d OntapAPIZAPI) VolumeRecoveryQueuePurge(ctx context.Context, recoveryQueueVolumeName string) error {
 	volRecoveryQueuePurgeResponse, err := d.api.VolumeRecoveryQueuePurge(recoveryQueueVolumeName)
 	if err != nil {

--- a/storage_drivers/ontap/api/ontap_rest.go
+++ b/storage_drivers/ontap/api/ontap_rest.go
@@ -1770,6 +1770,67 @@ func (c *RestClient) VolumeRecoveryQueueGetName(ctx context.Context, name string
 	return responseObject.Records[0].Volume, nil
 }
 
+// PreserveUnlinkSet uses the cli passthrough REST API to set the is-preserve-unlink-enabled option on a volume.
+// This volume option was introduced in 9.12.1 but not made visible via the /storage/volumes REST API endpoint.
+func (c *RestClient) PreserveUnlinkSet(ctx context.Context, volumeName string) error {
+	fields := LogFields{
+		"Method":     "PreserveUnlinkSet",
+		"Type":       "ontap_rest",
+		"volumeName": volumeName,
+		"vserver":    c.svmName,
+	}
+	Logd(ctx, c.driverName, c.config.DebugTraceFlags["method"]).WithFields(fields).
+		Trace(">>>> PreserveUnlinkSet")
+	defer Logd(ctx, c.driverName, c.config.DebugTraceFlags["method"]).WithFields(fields).
+		Trace("<<<< PrserveUnlinkSet")
+
+	requestUrl := fmt.Sprintf("https://%s/api/private/cli/volume?vserver=%s&volume=%s",
+		c.config.ManagementLIF, c.svmName, volumeName)
+
+	requestContent := map[string]string{
+		"is-preserve-unlink-enabled": "true",
+	}
+	requestBodyBytes, err := json.Marshal(requestContent)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPatch, requestUrl, bytes.NewReader(requestBodyBytes))
+	if err != nil {
+		return err
+	}
+
+	response, err := c.sendPassThroughCliCommand(ctx, request)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = response.Body.Close() }()
+
+	var responseBodyBytes []byte
+	var responseBodyString string
+	if response.Body != nil {
+		responseBodyBytes, _ = io.ReadAll(response.Body)
+		responseBodyString = string(responseBodyBytes)
+	} else {
+		Logc(ctx).WithField("statusCode", response.StatusCode).Error(
+			"no response when trying to set preserveUnlink.")
+		return fmt.Errorf("no response with status code: %v", response.StatusCode)
+	}
+	if response.StatusCode != http.StatusOK {
+		Logc(ctx).WithField("statusCode", response.StatusCode).Error(
+			"failed to set preserveUnlink: %s", responseBodyString)
+		return fmt.Errorf("unexpected response status code: %v", response.StatusCode)
+	}
+	if !strings.Contains(responseBodyString, "modify successful") {
+		Logc(ctx).WithField("statusCode", response.StatusCode).Error(
+			"unexpected response when setting preserveUnlink: %s", responseBodyString)
+		return fmt.Errorf("unexpected response boday with status code: %v", response.StatusCode)
+	}
+
+	return nil
+}
+
 func (c *RestClient) sendPassThroughCliCommand(ctx context.Context, request *http.Request) (*http.Response, error) {
 	request.Header.Set("Content-Type", "application/json")
 

--- a/storage_drivers/ontap/api/ontap_rest_interface.go
+++ b/storage_drivers/ontap/api/ontap_rest_interface.go
@@ -81,6 +81,8 @@ type RestClientInterface interface {
 	// directly purge the volume from the recovery queue.
 	VolumeRecoveryQueuePurge(ctx context.Context, recoveryQueueVolumeName string) error
 	VolumeRecoveryQueueGetName(ctx context.Context, name string) (string, error)
+	// PreserveUnlinkSet uses the cli passthrough REST API to to enable the volume is-preserve-unlink-enabled option.
+	PreserveUnlinkSet(ctx context.Context, volumeName string) error
 	// ConsistencyGroupCreateAndWait creates a CG and waits on the job to complete
 	ConsistencyGroupCreateAndWait(ctx context.Context, cgName string, flexVols []string) error
 	// ConsistencyGroupCreate creates a consistency group

--- a/storage_drivers/ontap/api/types.go
+++ b/storage_drivers/ontap/api/types.go
@@ -20,6 +20,7 @@ type Volume struct {
 	SnapshotDir       *bool
 	SnapshotPolicy    string
 	SnapshotReserve   int
+	PreserveUnlink    *bool
 	SnapshotSpaceUsed int
 	SpaceReserve      string
 	TieringPolicy     string

--- a/storage_drivers/types.go
+++ b/storage_drivers/types.go
@@ -198,6 +198,7 @@ type OntapStorageDriverConfigDefaults struct {
 	SpaceReserve      string `json:"spaceReserve"`
 	SnapshotPolicy    string `json:"snapshotPolicy"`
 	SnapshotReserve   string `json:"snapshotReserve"`
+	PreserveUnlink    string `json:"preserveUnlink"`
 	SnapshotDir       string `json:"snapshotDir"`
 	UnixPermissions   string `json:"unixPermissions"`
 	ExportPolicy      string `json:"exportPolicy"`


### PR DESCRIPTION
The ONTAP volume setting -is-preserve-unlink-enabled is required
for Kafka over NFS use cases.  This feature implements a Trident
PVC setting to enable this ONTAP volume setting with the ontap-nas
driver.

To enable this setting with an ontap-nas backend, use the following
in the backend definition defaults:

    "defaults": {
        "preserveUnlink": "true",
    }

Alternatively, this setting can also be enabled on a per PVC basis
with the following PVC annotation:

  annotations:
    trident.netapp.io/preserveUnlink: "true"

If no value is given for preserveUnlink in the backend or PVC
definition, it will default to "false".

While the is-preserve-unlink-enabled volume setting was first
introduced with ONTAP 9.12.1, this feature in Trident requires the
use of ONTAP 9.15.1 or higher where Trident uses the ONTAP REST API
by default.  The is-preserve-unlink-enabled volume setting in ONTAP
is not currently exposed by the ONTAP REST API, so we use the
