### PR TITLE
respect fractional sizes in gcnv

### DIFF
--- a/storage_drivers/gcp/gcp_gcnv.go
+++ b/storage_drivers/gcp/gcp_gcnv.go
@@ -777,6 +777,11 @@ func (d *NASStorageDriver) Create(
 		sizeBytes = minimumGCNVVolumeSizeBytes
 	}
 
+	// Ensure sizeBytes is a multiple of 1 GiB
+	if remainder := sizeBytes % capacity.OneGiB; remainder != 0 {
+		sizeBytes = ((sizeBytes / capacity.OneGiB) + 1) * capacity.OneGiB
+	}
+
 	// Get the volume size based on the snapshot reserve
 	sizeWithReserveBytes := drivers.CalculateVolumeSizeBytes(ctx, name, sizeBytes, snapshotReserveInt)
 
@@ -2070,6 +2075,12 @@ func (d *NASStorageDriver) Resize(ctx context.Context, volConfig *storage.Volume
 	if volume.SnapshotReserve > math.MaxInt {
 		return fmt.Errorf("snapshot reserve too large")
 	}
+
+	// Ensure sizeBytes is a multiple of 1 GiB
+	if remainder := sizeBytes % capacity.OneGiB; remainder != 0 {
+		sizeBytes = ((sizeBytes / capacity.OneGiB) + 1) * capacity.OneGiB
+	}
+
 	sizeWithReserveBytes := drivers.CalculateVolumeSizeBytes(ctx, name, sizeBytes, int(volume.SnapshotReserve))
 
 	// If the volume is already the requested size, there's nothing to do


### PR DESCRIPTION

## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 
today gcnv completely discards fractional sizes
and picks the floor from the 1Gi aligment result
i.e. 10.6Gi results in 10Gi volume which does not satisfy the user request
Fixes #1110 

## Project tracking
<!-- What is the Jira Issue URL for this PR? -->


## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->


## Did you add unit tests? Why not?


## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->


## Is a code review walkthrough needed? why or why not?


## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->


## Does this code need a note in the changelog?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->


## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->


## Additional Information
Not 100% sure if I should tackle the calculation post snapshot reserve, would appreciate some guidelines
