### PR TITLE
utils/mount/mount_linux.go: replace 'mkdir -p' invocation with MkdirAll() standard Go function

### DIFF
--- a/utils/mount/mount_linux.go
+++ b/utils/mount/mount_linux.go
@@ -197,7 +197,7 @@ func (client *LinuxClient) MountNFSPath(ctx context.Context, exportPath, mountpo
 	}
 
 	// Create the mount point dir if necessary
-	if _, err := client.command.Execute(ctx, "mkdir", "-p", mountpoint); err != nil {
+	if err := client.os.MkdirAll(mountpoint, 0o755); err != nil {
 		Logc(ctx).WithField("error", err).Warning("Mkdir failed.")
 	}
 


### PR DESCRIPTION
## Change description
It makes trident possible to use on Talos at least with NFS https://github.com/NetApp/trident/issues/806

mount.nfs* tools are already being added to the image, see https://github.com/NetApp/trident/blob/v26.02.1/Dockerfile#L13 for example.

So `mkdir` was the only reason why trident could not be used on Talos with NFS4.

## Does this code need a note in the changelog?
Customer won't see the difference, so rather no.