### PR TITLE
Add structural schemas for operator CRDs

### DIFF
--- a/cli/k8s_client/yaml_factory.go
+++ b/cli/k8s_client/yaml_factory.go
@@ -2670,9 +2670,35 @@ spec:
       served: true
       storage: true
       schema:
-          openAPIV3Schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                backendNames:
+                  type: array
+                  items:
+                    type: string
+                message:
+                  type: string
+                deletionPolicy:
+                  type: string
+                phase:
+                  type: string
+                lastOperationStatus:
+                  type: string
+                cloudProvider:
+                  type: string
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -3028,7 +3054,224 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                enableForceDetach:
+                  type: boolean
+                disableAuditLog:
+                  type: boolean
+                namespace:
+                  type: string
+                IPv6:
+                  type: boolean
+                k8sTimeout:
+                  type: integer
+                httpRequestTimeout:
+                  type: string
+                silenceAutosupport:
+                  type: boolean
+                excludeAutosupport:
+                  type: boolean
+                autosupportImage:
+                  type: string
+                autosupportProxy:
+                  type: string
+                autosupportInsecure:
+                  type: boolean
+                autosupportSerialNumber:
+                  type: string
+                autosupportHostname:
+                  type: string
+                uninstall:
+                  type: boolean
+                logFormat:
+                  type: string
+                logLevel:
+                  type: string
+                debug:
+                  type: boolean
+                logWorkflows:
+                  type: string
+                logLayers:
+                  type: string
+                probePort:
+                  type: integer
+                  format: int64
+                tridentImage:
+                  type: string
+                imageRegistry:
+                  type: string
+                kubeletDir:
+                  type: string
+                wipeout:
+                  type: array
+                  items:
+                    type: string
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: string
+                controllerPluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                controllerPluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                nodePluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                nodePluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                windows:
+                  type: boolean
+                imagePullPolicy:
+                  type: string
+                cloudProvider:
+                  type: string
+                cloudIdentity:
+                  type: string
+                enableACP:
+                  type: boolean
+                acpImage:
+                  type: string
+                enableAutoBackendConfig:
+                  type: boolean
+                iscsiSelfHealingInterval:
+                  type: string
+                iscsiSelfHealingWaitTime:
+                  type: string
+                k8sAPIQPS:
+                  type: integer
+                fsGroupPolicy:
+                  type: string
+                nodePrep:
+                  type: array
+                  items:
+                    type: string
+                skipCRDsToObliviate:
+                  type: array
+                  items:
+                    type: string
+                enableConcurrency:
+                  type: boolean
+                resources:
+                  type: object
+                  properties:
+                    controller:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                    node:
+                      type: object
+                      properties:
+                        linux:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                        windows:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                httpsMetrics:
+                  type: boolean
+                hostNetwork:
+                  type: boolean
+            status:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                version:
+                  type: string
+                namespace:
+                  type: string
+                currentInstallationParams:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                acpVersion:
+                  type: string
       subresources:
         status: {}
   names:

--- a/cli/k8s_client/yaml_factory.go
+++ b/cli/k8s_client/yaml_factory.go
@@ -2693,9 +2693,35 @@ spec:
       served: true
       storage: true
       schema:
-          openAPIV3Schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                backendNames:
+                  type: array
+                  items:
+                    type: string
+                message:
+                  type: string
+                deletionPolicy:
+                  type: string
+                phase:
+                  type: string
+                lastOperationStatus:
+                  type: string
+                cloudProvider:
+                  type: string
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -3087,7 +3113,224 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                enableForceDetach:
+                  type: boolean
+                disableAuditLog:
+                  type: boolean
+                namespace:
+                  type: string
+                IPv6:
+                  type: boolean
+                k8sTimeout:
+                  type: integer
+                httpRequestTimeout:
+                  type: string
+                silenceAutosupport:
+                  type: boolean
+                excludeAutosupport:
+                  type: boolean
+                autosupportImage:
+                  type: string
+                autosupportProxy:
+                  type: string
+                autosupportInsecure:
+                  type: boolean
+                autosupportSerialNumber:
+                  type: string
+                autosupportHostname:
+                  type: string
+                uninstall:
+                  type: boolean
+                logFormat:
+                  type: string
+                logLevel:
+                  type: string
+                debug:
+                  type: boolean
+                logWorkflows:
+                  type: string
+                logLayers:
+                  type: string
+                probePort:
+                  type: integer
+                  format: int64
+                tridentImage:
+                  type: string
+                imageRegistry:
+                  type: string
+                kubeletDir:
+                  type: string
+                wipeout:
+                  type: array
+                  items:
+                    type: string
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: string
+                controllerPluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                controllerPluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                nodePluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                nodePluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                windows:
+                  type: boolean
+                imagePullPolicy:
+                  type: string
+                cloudProvider:
+                  type: string
+                cloudIdentity:
+                  type: string
+                enableACP:
+                  type: boolean
+                acpImage:
+                  type: string
+                enableAutoBackendConfig:
+                  type: boolean
+                iscsiSelfHealingInterval:
+                  type: string
+                iscsiSelfHealingWaitTime:
+                  type: string
+                k8sAPIQPS:
+                  type: integer
+                fsGroupPolicy:
+                  type: string
+                nodePrep:
+                  type: array
+                  items:
+                    type: string
+                skipCRDsToObliviate:
+                  type: array
+                  items:
+                    type: string
+                enableConcurrency:
+                  type: boolean
+                resources:
+                  type: object
+                  properties:
+                    controller:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                    node:
+                      type: object
+                      properties:
+                        linux:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                        windows:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                httpsMetrics:
+                  type: boolean
+                hostNetwork:
+                  type: boolean
+            status:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                version:
+                  type: string
+                namespace:
+                  type: string
+                currentInstallationParams:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                acpVersion:
+                  type: string
       subresources:
         status: {}
   names:

--- a/cli/k8s_client/yaml_factory_test.go
+++ b/cli/k8s_client/yaml_factory_test.go
@@ -1904,8 +1904,50 @@ func getVersionAPIExtension(t *testing.T) apiextensionsv1.CustomResourceDefiniti
 	t.Helper()
 	schema := apiextensionsv1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				"apiVersion": {
+					Type: "string",
+				},
+				"kind": {
+					Type: "string",
+				},
+				"metadata": {
+					Type: "object",
+				},
+				"spec": {
+					Type:                   "object",
+					XPreserveUnknownFields: new(true),
+				},
+				"status": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"backendNames": {
+							Type: "array",
+							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+								Schema: &apiextensionsv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						"message": {
+							Type: "string",
+						},
+						"deletionPolicy": {
+							Type: "string",
+						},
+						"phase": {
+							Type: "string",
+						},
+						"lastOperationStatus": {
+							Type: "string",
+						},
+						"cloudProvider": {
+							Type: "string",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -2984,82 +3026,10 @@ func getActionSnapshotRestoreAPIExtension(t *testing.T) apiextensionsv1.CustomRe
 
 func getConfiguratorsAPIExtension(t *testing.T) apiextensionsv1.CustomResourceDefinition {
 	t.Helper()
-	schema := apiextensionsv1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
-		},
-	}
 
-	return apiextensionsv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tridentconfigurators.trident.netapp.io",
-		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "trident.netapp.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:     "tridentconfigurators",
-				Singular:   "tridentconfigurator",
-				Kind:       "TridentConfigurator",
-				ShortNames: []string{"tconf", "tconfigurator"},
-				Categories: []string{"trident", "trident-internal", "trident-external"},
-			},
-			Scope: "Cluster",
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema:  &schema,
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-						Scale:  nil,
-					},
-					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
-						{
-							Name:        "Phase",
-							Type:        "string",
-							Description: "The backend config phase",
-							Priority:    int32(0),
-							JSONPath:    ".status.phase",
-						},
-						{
-							Name:        "Status",
-							Type:        "string",
-							Description: "The result of the last operation",
-							Priority:    int32(0),
-							JSONPath:    ".status.lastOperationStatus",
-						},
-						{
-							Name:        "Cloud Provider",
-							Type:        "string",
-							Description: "The name of cloud provider",
-							Priority:    int32(0),
-							JSONPath:    ".status.cloudProvider",
-						},
-						{
-							Name:        "Storage Driver",
-							Type:        "string",
-							Description: "The storage driver type",
-							Priority:    int32(1),
-							JSONPath:    ".spec.storageDriverName",
-						},
-						{
-							Name:        "Deletion Policy",
-							Type:        "string",
-							Description: "The deletion policy",
-							Priority:    int32(1),
-							JSONPath:    ".status.deletionPolicy",
-						},
-					},
-				},
-			},
-		},
-	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	require.NoError(t, yaml.Unmarshal([]byte(tridentConfiguratorCRDYAMLv1), &crd), "invalid YAML")
+	return crd
 }
 
 func TestGetBackendConfigCRDYAML(t *testing.T) {
@@ -3074,14 +3044,39 @@ func TestGetBackendConfigCRDYAML(t *testing.T) {
 }
 
 func TestGetConfiguratorCRDYAML(t *testing.T) {
-	expected := getConfiguratorsAPIExtension(t)
 	actualYAML := GetConfiguratorCRDYAML()
 
 	var actual apiextensionsv1.CustomResourceDefinition
 	assert.Nil(t, yaml.Unmarshal([]byte(actualYAML), &actual), "invalid YAML")
-	assert.True(t, reflect.DeepEqual(expected.TypeMeta, actual.TypeMeta))
-	assert.True(t, reflect.DeepEqual(expected.ObjectMeta, actual.ObjectMeta))
-	assert.True(t, reflect.DeepEqual(expected.Spec, actual.Spec))
+	assert.Equal(t, metav1.TypeMeta{
+		Kind:       "CustomResourceDefinition",
+		APIVersion: "apiextensions.k8s.io/v1",
+	}, actual.TypeMeta)
+	assert.Equal(t, "tridentconfigurators.trident.netapp.io", actual.Name)
+	assert.Equal(t, "trident.netapp.io", actual.Spec.Group)
+	assert.Equal(t, "Cluster", string(actual.Spec.Scope))
+	assert.Equal(t, apiextensionsv1.CustomResourceDefinitionNames{
+		Plural:     "tridentconfigurators",
+		Singular:   "tridentconfigurator",
+		Kind:       "TridentConfigurator",
+		ShortNames: []string{"tconf", "tconfigurator"},
+		Categories: []string{"trident", "trident-internal", "trident-external"},
+	}, actual.Spec.Names)
+
+	require.Len(t, actual.Spec.Versions, 1)
+	version := actual.Spec.Versions[0]
+	require.NotNil(t, version.Schema)
+	require.NotNil(t, version.Schema.OpenAPIV3Schema)
+	schema := version.Schema.OpenAPIV3Schema
+
+	assert.Equal(t, "object", schema.Type)
+	assert.Nil(t, schema.XPreserveUnknownFields)
+	assert.Equal(t, "object", schema.Properties["spec"].Type)
+	require.NotNil(t, schema.Properties["spec"].XPreserveUnknownFields)
+	assert.True(t, *schema.Properties["spec"].XPreserveUnknownFields)
+	assert.Equal(t, "object", schema.Properties["status"].Type)
+	assert.Equal(t, "array", schema.Properties["status"].Properties["backendNames"].Type)
+	assert.Equal(t, "string", schema.Properties["status"].Properties["phase"].Type)
 }
 
 func TestGetMirrorRelationshipCRDYAML(t *testing.T) {
@@ -3184,52 +3179,66 @@ func TestGetGroupSnapshotCRDYAML(t *testing.T) {
 }
 
 func TestGetOrchestratorCRDYAML(t *testing.T) {
-	schema := apiextensionsv1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
-		},
-	}
-	expected := apiextensionsv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tridentorchestrators.trident.netapp.io",
-		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "trident.netapp.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:     "tridentorchestrators",
-				Singular:   "tridentorchestrator",
-				Kind:       "TridentOrchestrator",
-				ListKind:   "TridentOrchestratorList",
-				ShortNames: []string{"torc", "torchestrator"},
-			},
-			Scope: "Cluster",
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema:  &schema,
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-						Scale:  nil,
-					},
-				},
-			},
-		},
+	assertSchemaProperty := func(t *testing.T, schema *apiextensionsv1.JSONSchemaProps, path []string, expectedType string) {
+		t.Helper()
+
+		current := schema
+		for _, segment := range path {
+			next, ok := current.Properties[segment]
+			assert.True(t, ok, "missing schema property %q in path %v", segment, path)
+			current = &next
+		}
+		assert.Equal(t, expectedType, current.Type, "unexpected schema type for path %v", path)
 	}
 
 	actualYAML := GetOrchestratorCRDYAML()
 
 	var actual apiextensionsv1.CustomResourceDefinition
 	assert.Nil(t, yaml.Unmarshal([]byte(actualYAML), &actual), "invalid YAML")
-	assert.True(t, reflect.DeepEqual(expected.TypeMeta, actual.TypeMeta))
-	assert.True(t, reflect.DeepEqual(expected.ObjectMeta, actual.ObjectMeta))
-	assert.True(t, reflect.DeepEqual(expected.Spec, actual.Spec))
+	assert.Equal(t, metav1.TypeMeta{
+		Kind:       "CustomResourceDefinition",
+		APIVersion: "apiextensions.k8s.io/v1",
+	}, actual.TypeMeta)
+	assert.Equal(t, "tridentorchestrators.trident.netapp.io", actual.Name)
+	assert.Equal(t, "trident.netapp.io", actual.Spec.Group)
+	assert.Equal(t, "Cluster", string(actual.Spec.Scope))
+	assert.Equal(t, apiextensionsv1.CustomResourceDefinitionNames{
+		Plural:     "tridentorchestrators",
+		Singular:   "tridentorchestrator",
+		Kind:       "TridentOrchestrator",
+		ListKind:   "TridentOrchestratorList",
+		ShortNames: []string{"torc", "torchestrator"},
+	}, actual.Spec.Names)
+
+	require.Len(t, actual.Spec.Versions, 1)
+	version := actual.Spec.Versions[0]
+	assert.Equal(t, "v1", version.Name)
+	assert.True(t, version.Served)
+	assert.True(t, version.Storage)
+	require.NotNil(t, version.Subresources)
+	assert.NotNil(t, version.Subresources.Status)
+	require.NotNil(t, version.Schema)
+	require.NotNil(t, version.Schema.OpenAPIV3Schema)
+
+	schema := version.Schema.OpenAPIV3Schema
+	assert.Equal(t, "object", schema.Type)
+	assert.Nil(t, schema.XPreserveUnknownFields)
+	assertSchemaProperty(t, schema, []string{"spec"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "namespace"}, "string")
+	assertSchemaProperty(t, schema, []string{"spec", "enableForceDetach"}, "boolean")
+	assertSchemaProperty(t, schema, []string{"spec", "probePort"}, "integer")
+	assertSchemaProperty(t, schema, []string{"spec", "imagePullSecrets"}, "array")
+	assertSchemaProperty(t, schema, []string{"spec", "controllerPluginNodeSelector"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "controllerPluginTolerations"}, "array")
+	assertSchemaProperty(t, schema, []string{"spec", "resources"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "resources", "controller"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "resources", "node", "linux"}, "object")
+	assertSchemaProperty(t, schema, []string{"status"}, "object")
+	assertSchemaProperty(t, schema, []string{"status", "message"}, "string")
+
+	currentInstallationParams := schema.Properties["status"].Properties["currentInstallationParams"]
+	require.NotNil(t, currentInstallationParams.XPreserveUnknownFields)
+	assert.True(t, *currentInstallationParams.XPreserveUnknownFields)
 }
 
 func TestGetActionMirrorUpdateCRDYAML(t *testing.T) {

--- a/cli/k8s_client/yaml_factory_test.go
+++ b/cli/k8s_client/yaml_factory_test.go
@@ -1904,8 +1904,50 @@ func getVersionAPIExtension(t *testing.T) apiextensionsv1.CustomResourceDefiniti
 	t.Helper()
 	schema := apiextensionsv1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				"apiVersion": {
+					Type: "string",
+				},
+				"kind": {
+					Type: "string",
+				},
+				"metadata": {
+					Type: "object",
+				},
+				"spec": {
+					Type:                   "object",
+					XPreserveUnknownFields: new(true),
+				},
+				"status": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"backendNames": {
+							Type: "array",
+							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+								Schema: &apiextensionsv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						"message": {
+							Type: "string",
+						},
+						"deletionPolicy": {
+							Type: "string",
+						},
+						"phase": {
+							Type: "string",
+						},
+						"lastOperationStatus": {
+							Type: "string",
+						},
+						"cloudProvider": {
+							Type: "string",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -3033,82 +3075,10 @@ func getActionSnapshotRestoreAPIExtension(t *testing.T) apiextensionsv1.CustomRe
 
 func getConfiguratorsAPIExtension(t *testing.T) apiextensionsv1.CustomResourceDefinition {
 	t.Helper()
-	schema := apiextensionsv1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
-		},
-	}
 
-	return apiextensionsv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tridentconfigurators.trident.netapp.io",
-		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "trident.netapp.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:     "tridentconfigurators",
-				Singular:   "tridentconfigurator",
-				Kind:       "TridentConfigurator",
-				ShortNames: []string{"tconf", "tconfigurator"},
-				Categories: []string{"trident", "trident-internal", "trident-external"},
-			},
-			Scope: "Cluster",
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema:  &schema,
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-						Scale:  nil,
-					},
-					AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{
-						{
-							Name:        "Phase",
-							Type:        "string",
-							Description: "The backend config phase",
-							Priority:    int32(0),
-							JSONPath:    ".status.phase",
-						},
-						{
-							Name:        "Status",
-							Type:        "string",
-							Description: "The result of the last operation",
-							Priority:    int32(0),
-							JSONPath:    ".status.lastOperationStatus",
-						},
-						{
-							Name:        "Cloud Provider",
-							Type:        "string",
-							Description: "The name of cloud provider",
-							Priority:    int32(0),
-							JSONPath:    ".status.cloudProvider",
-						},
-						{
-							Name:        "Storage Driver",
-							Type:        "string",
-							Description: "The storage driver type",
-							Priority:    int32(1),
-							JSONPath:    ".spec.storageDriverName",
-						},
-						{
-							Name:        "Deletion Policy",
-							Type:        "string",
-							Description: "The deletion policy",
-							Priority:    int32(1),
-							JSONPath:    ".status.deletionPolicy",
-						},
-					},
-				},
-			},
-		},
-	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	require.NoError(t, yaml.Unmarshal([]byte(tridentConfiguratorCRDYAMLv1), &crd), "invalid YAML")
+	return crd
 }
 
 func TestGetBackendConfigCRDYAML(t *testing.T) {
@@ -3123,14 +3093,39 @@ func TestGetBackendConfigCRDYAML(t *testing.T) {
 }
 
 func TestGetConfiguratorCRDYAML(t *testing.T) {
-	expected := getConfiguratorsAPIExtension(t)
 	actualYAML := GetConfiguratorCRDYAML()
 
 	var actual apiextensionsv1.CustomResourceDefinition
 	assert.Nil(t, yaml.Unmarshal([]byte(actualYAML), &actual), "invalid YAML")
-	assert.True(t, reflect.DeepEqual(expected.TypeMeta, actual.TypeMeta))
-	assert.True(t, reflect.DeepEqual(expected.ObjectMeta, actual.ObjectMeta))
-	assert.True(t, reflect.DeepEqual(expected.Spec, actual.Spec))
+	assert.Equal(t, metav1.TypeMeta{
+		Kind:       "CustomResourceDefinition",
+		APIVersion: "apiextensions.k8s.io/v1",
+	}, actual.TypeMeta)
+	assert.Equal(t, "tridentconfigurators.trident.netapp.io", actual.Name)
+	assert.Equal(t, "trident.netapp.io", actual.Spec.Group)
+	assert.Equal(t, "Cluster", string(actual.Spec.Scope))
+	assert.Equal(t, apiextensionsv1.CustomResourceDefinitionNames{
+		Plural:     "tridentconfigurators",
+		Singular:   "tridentconfigurator",
+		Kind:       "TridentConfigurator",
+		ShortNames: []string{"tconf", "tconfigurator"},
+		Categories: []string{"trident", "trident-internal", "trident-external"},
+	}, actual.Spec.Names)
+
+	require.Len(t, actual.Spec.Versions, 1)
+	version := actual.Spec.Versions[0]
+	require.NotNil(t, version.Schema)
+	require.NotNil(t, version.Schema.OpenAPIV3Schema)
+	schema := version.Schema.OpenAPIV3Schema
+
+	assert.Equal(t, "object", schema.Type)
+	assert.Nil(t, schema.XPreserveUnknownFields)
+	assert.Equal(t, "object", schema.Properties["spec"].Type)
+	require.NotNil(t, schema.Properties["spec"].XPreserveUnknownFields)
+	assert.True(t, *schema.Properties["spec"].XPreserveUnknownFields)
+	assert.Equal(t, "object", schema.Properties["status"].Type)
+	assert.Equal(t, "array", schema.Properties["status"].Properties["backendNames"].Type)
+	assert.Equal(t, "string", schema.Properties["status"].Properties["phase"].Type)
 }
 
 func TestGetMirrorRelationshipCRDYAML(t *testing.T) {
@@ -3233,52 +3228,66 @@ func TestGetGroupSnapshotCRDYAML(t *testing.T) {
 }
 
 func TestGetOrchestratorCRDYAML(t *testing.T) {
-	schema := apiextensionsv1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type:                   "object",
-			XPreserveUnknownFields: new(true),
-		},
-	}
-	expected := apiextensionsv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tridentorchestrators.trident.netapp.io",
-		},
-		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: "trident.netapp.io",
-			Names: apiextensionsv1.CustomResourceDefinitionNames{
-				Plural:     "tridentorchestrators",
-				Singular:   "tridentorchestrator",
-				Kind:       "TridentOrchestrator",
-				ListKind:   "TridentOrchestratorList",
-				ShortNames: []string{"torc", "torchestrator"},
-			},
-			Scope: "Cluster",
-			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-					Schema:  &schema,
-					Subresources: &apiextensionsv1.CustomResourceSubresources{
-						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
-						Scale:  nil,
-					},
-				},
-			},
-		},
+	assertSchemaProperty := func(t *testing.T, schema *apiextensionsv1.JSONSchemaProps, path []string, expectedType string) {
+		t.Helper()
+
+		current := schema
+		for _, segment := range path {
+			next, ok := current.Properties[segment]
+			assert.True(t, ok, "missing schema property %q in path %v", segment, path)
+			current = &next
+		}
+		assert.Equal(t, expectedType, current.Type, "unexpected schema type for path %v", path)
 	}
 
 	actualYAML := GetOrchestratorCRDYAML()
 
 	var actual apiextensionsv1.CustomResourceDefinition
 	assert.Nil(t, yaml.Unmarshal([]byte(actualYAML), &actual), "invalid YAML")
-	assert.True(t, reflect.DeepEqual(expected.TypeMeta, actual.TypeMeta))
-	assert.True(t, reflect.DeepEqual(expected.ObjectMeta, actual.ObjectMeta))
-	assert.True(t, reflect.DeepEqual(expected.Spec, actual.Spec))
+	assert.Equal(t, metav1.TypeMeta{
+		Kind:       "CustomResourceDefinition",
+		APIVersion: "apiextensions.k8s.io/v1",
+	}, actual.TypeMeta)
+	assert.Equal(t, "tridentorchestrators.trident.netapp.io", actual.Name)
+	assert.Equal(t, "trident.netapp.io", actual.Spec.Group)
+	assert.Equal(t, "Cluster", string(actual.Spec.Scope))
+	assert.Equal(t, apiextensionsv1.CustomResourceDefinitionNames{
+		Plural:     "tridentorchestrators",
+		Singular:   "tridentorchestrator",
+		Kind:       "TridentOrchestrator",
+		ListKind:   "TridentOrchestratorList",
+		ShortNames: []string{"torc", "torchestrator"},
+	}, actual.Spec.Names)
+
+	require.Len(t, actual.Spec.Versions, 1)
+	version := actual.Spec.Versions[0]
+	assert.Equal(t, "v1", version.Name)
+	assert.True(t, version.Served)
+	assert.True(t, version.Storage)
+	require.NotNil(t, version.Subresources)
+	assert.NotNil(t, version.Subresources.Status)
+	require.NotNil(t, version.Schema)
+	require.NotNil(t, version.Schema.OpenAPIV3Schema)
+
+	schema := version.Schema.OpenAPIV3Schema
+	assert.Equal(t, "object", schema.Type)
+	assert.Nil(t, schema.XPreserveUnknownFields)
+	assertSchemaProperty(t, schema, []string{"spec"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "namespace"}, "string")
+	assertSchemaProperty(t, schema, []string{"spec", "enableForceDetach"}, "boolean")
+	assertSchemaProperty(t, schema, []string{"spec", "probePort"}, "integer")
+	assertSchemaProperty(t, schema, []string{"spec", "imagePullSecrets"}, "array")
+	assertSchemaProperty(t, schema, []string{"spec", "controllerPluginNodeSelector"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "controllerPluginTolerations"}, "array")
+	assertSchemaProperty(t, schema, []string{"spec", "resources"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "resources", "controller"}, "object")
+	assertSchemaProperty(t, schema, []string{"spec", "resources", "node", "linux"}, "object")
+	assertSchemaProperty(t, schema, []string{"status"}, "object")
+	assertSchemaProperty(t, schema, []string{"status", "message"}, "string")
+
+	currentInstallationParams := schema.Properties["status"].Properties["currentInstallationParams"]
+	require.NotNil(t, currentInstallationParams.XPreserveUnknownFields)
+	assert.True(t, *currentInstallationParams.XPreserveUnknownFields)
 }
 
 func TestGetActionMirrorUpdateCRDYAML(t *testing.T) {

--- a/cli/k8s_client/yaml_factory_test.go
+++ b/cli/k8s_client/yaml_factory_test.go
@@ -1904,50 +1904,8 @@ func getVersionAPIExtension(t *testing.T) apiextensionsv1.CustomResourceDefiniti
 	t.Helper()
 	schema := apiextensionsv1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-			Type: "object",
-			Properties: map[string]apiextensionsv1.JSONSchemaProps{
-				"apiVersion": {
-					Type: "string",
-				},
-				"kind": {
-					Type: "string",
-				},
-				"metadata": {
-					Type: "object",
-				},
-				"spec": {
-					Type:                   "object",
-					XPreserveUnknownFields: new(true),
-				},
-				"status": {
-					Type: "object",
-					Properties: map[string]apiextensionsv1.JSONSchemaProps{
-						"backendNames": {
-							Type: "array",
-							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
-								Schema: &apiextensionsv1.JSONSchemaProps{
-									Type: "string",
-								},
-							},
-						},
-						"message": {
-							Type: "string",
-						},
-						"deletionPolicy": {
-							Type: "string",
-						},
-						"phase": {
-							Type: "string",
-						},
-						"lastOperationStatus": {
-							Type: "string",
-						},
-						"cloudProvider": {
-							Type: "string",
-						},
-					},
-				},
-			},
+			Type:                   "object",
+			XPreserveUnknownFields: new(true),
 		},
 	}
 

--- a/deploy/crds/trident.netapp.io_tridentconfigurators_crd.yaml
+++ b/deploy/crds/trident.netapp.io_tridentconfigurators_crd.yaml
@@ -11,7 +11,33 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                backendNames:
+                  type: array
+                  items:
+                    type: string
+                message:
+                  type: string
+                deletionPolicy:
+                  type: string
+                phase:
+                  type: string
+                lastOperationStatus:
+                  type: string
+                cloudProvider:
+                  type: string
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/deploy/crds/trident.netapp.io_tridentorchestrators_crd.yaml
+++ b/deploy/crds/trident.netapp.io_tridentorchestrators_crd.yaml
@@ -11,7 +11,224 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                enableForceDetach:
+                  type: boolean
+                disableAuditLog:
+                  type: boolean
+                namespace:
+                  type: string
+                IPv6:
+                  type: boolean
+                k8sTimeout:
+                  type: integer
+                httpRequestTimeout:
+                  type: string
+                silenceAutosupport:
+                  type: boolean
+                excludeAutosupport:
+                  type: boolean
+                autosupportImage:
+                  type: string
+                autosupportProxy:
+                  type: string
+                autosupportInsecure:
+                  type: boolean
+                autosupportSerialNumber:
+                  type: string
+                autosupportHostname:
+                  type: string
+                uninstall:
+                  type: boolean
+                logFormat:
+                  type: string
+                logLevel:
+                  type: string
+                debug:
+                  type: boolean
+                logWorkflows:
+                  type: string
+                logLayers:
+                  type: string
+                probePort:
+                  type: integer
+                  format: int64
+                tridentImage:
+                  type: string
+                imageRegistry:
+                  type: string
+                kubeletDir:
+                  type: string
+                wipeout:
+                  type: array
+                  items:
+                    type: string
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: string
+                controllerPluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                controllerPluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                nodePluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                nodePluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                windows:
+                  type: boolean
+                imagePullPolicy:
+                  type: string
+                cloudProvider:
+                  type: string
+                cloudIdentity:
+                  type: string
+                enableACP:
+                  type: boolean
+                acpImage:
+                  type: string
+                enableAutoBackendConfig:
+                  type: boolean
+                iscsiSelfHealingInterval:
+                  type: string
+                iscsiSelfHealingWaitTime:
+                  type: string
+                k8sAPIQPS:
+                  type: integer
+                fsGroupPolicy:
+                  type: string
+                nodePrep:
+                  type: array
+                  items:
+                    type: string
+                skipCRDsToObliviate:
+                  type: array
+                  items:
+                    type: string
+                enableConcurrency:
+                  type: boolean
+                resources:
+                  type: object
+                  properties:
+                    controller:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                    node:
+                      type: object
+                      properties:
+                        linux:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                        windows:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                httpsMetrics:
+                  type: boolean
+                hostNetwork:
+                  type: boolean
+            status:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                version:
+                  type: string
+                namespace:
+                  type: string
+                currentInstallationParams:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                acpVersion:
+                  type: string
       subresources:
         status: {}
   names:

--- a/deploy/crds/trident.netapp.io_tridentorchestrators_crd_post1.16.yaml
+++ b/deploy/crds/trident.netapp.io_tridentorchestrators_crd_post1.16.yaml
@@ -11,7 +11,224 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                enableForceDetach:
+                  type: boolean
+                disableAuditLog:
+                  type: boolean
+                namespace:
+                  type: string
+                IPv6:
+                  type: boolean
+                k8sTimeout:
+                  type: integer
+                httpRequestTimeout:
+                  type: string
+                silenceAutosupport:
+                  type: boolean
+                excludeAutosupport:
+                  type: boolean
+                autosupportImage:
+                  type: string
+                autosupportProxy:
+                  type: string
+                autosupportInsecure:
+                  type: boolean
+                autosupportSerialNumber:
+                  type: string
+                autosupportHostname:
+                  type: string
+                uninstall:
+                  type: boolean
+                logFormat:
+                  type: string
+                logLevel:
+                  type: string
+                debug:
+                  type: boolean
+                logWorkflows:
+                  type: string
+                logLayers:
+                  type: string
+                probePort:
+                  type: integer
+                  format: int64
+                tridentImage:
+                  type: string
+                imageRegistry:
+                  type: string
+                kubeletDir:
+                  type: string
+                wipeout:
+                  type: array
+                  items:
+                    type: string
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: string
+                controllerPluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                controllerPluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                nodePluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                nodePluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                windows:
+                  type: boolean
+                imagePullPolicy:
+                  type: string
+                cloudProvider:
+                  type: string
+                cloudIdentity:
+                  type: string
+                enableACP:
+                  type: boolean
+                acpImage:
+                  type: string
+                enableAutoBackendConfig:
+                  type: boolean
+                iscsiSelfHealingInterval:
+                  type: string
+                iscsiSelfHealingWaitTime:
+                  type: string
+                k8sAPIQPS:
+                  type: integer
+                fsGroupPolicy:
+                  type: string
+                nodePrep:
+                  type: array
+                  items:
+                    type: string
+                skipCRDsToObliviate:
+                  type: array
+                  items:
+                    type: string
+                enableConcurrency:
+                  type: boolean
+                resources:
+                  type: object
+                  properties:
+                    controller:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                    node:
+                      type: object
+                      properties:
+                        linux:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                        windows:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                httpsMetrics:
+                  type: boolean
+                hostNetwork:
+                  type: boolean
+            status:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                version:
+                  type: string
+                namespace:
+                  type: string
+                currentInstallationParams:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                acpVersion:
+                  type: string
       subresources:
         status: {}
   names:

--- a/helm/trident-operator/crds/tridentconfigurators.yaml
+++ b/helm/trident-operator/crds/tridentconfigurators.yaml
@@ -11,7 +11,33 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                backendNames:
+                  type: array
+                  items:
+                    type: string
+                message:
+                  type: string
+                deletionPolicy:
+                  type: string
+                phase:
+                  type: string
+                lastOperationStatus:
+                  type: string
+                cloudProvider:
+                  type: string
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/helm/trident-operator/crds/tridentorchestrators.yaml
+++ b/helm/trident-operator/crds/tridentorchestrators.yaml
@@ -11,7 +11,224 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                enableForceDetach:
+                  type: boolean
+                disableAuditLog:
+                  type: boolean
+                namespace:
+                  type: string
+                IPv6:
+                  type: boolean
+                k8sTimeout:
+                  type: integer
+                httpRequestTimeout:
+                  type: string
+                silenceAutosupport:
+                  type: boolean
+                excludeAutosupport:
+                  type: boolean
+                autosupportImage:
+                  type: string
+                autosupportProxy:
+                  type: string
+                autosupportInsecure:
+                  type: boolean
+                autosupportSerialNumber:
+                  type: string
+                autosupportHostname:
+                  type: string
+                uninstall:
+                  type: boolean
+                logFormat:
+                  type: string
+                logLevel:
+                  type: string
+                debug:
+                  type: boolean
+                logWorkflows:
+                  type: string
+                logLayers:
+                  type: string
+                probePort:
+                  type: integer
+                  format: int64
+                tridentImage:
+                  type: string
+                imageRegistry:
+                  type: string
+                kubeletDir:
+                  type: string
+                wipeout:
+                  type: array
+                  items:
+                    type: string
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: string
+                controllerPluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                controllerPluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                nodePluginNodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                nodePluginTolerations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      value:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                windows:
+                  type: boolean
+                imagePullPolicy:
+                  type: string
+                cloudProvider:
+                  type: string
+                cloudIdentity:
+                  type: string
+                enableACP:
+                  type: boolean
+                acpImage:
+                  type: string
+                enableAutoBackendConfig:
+                  type: boolean
+                iscsiSelfHealingInterval:
+                  type: string
+                iscsiSelfHealingWaitTime:
+                  type: string
+                k8sAPIQPS:
+                  type: integer
+                fsGroupPolicy:
+                  type: string
+                nodePrep:
+                  type: array
+                  items:
+                    type: string
+                skipCRDsToObliviate:
+                  type: array
+                  items:
+                    type: string
+                enableConcurrency:
+                  type: boolean
+                resources:
+                  type: object
+                  properties:
+                    controller:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                    node:
+                      type: object
+                      properties:
+                        linux:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                        windows:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            properties:
+                              requests:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                              limits:
+                                type: object
+                                properties:
+                                  cpu:
+                                    type: string
+                                  memory:
+                                    type: string
+                httpsMetrics:
+                  type: boolean
+                hostNetwork:
+                  type: boolean
+            status:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                version:
+                  type: string
+                namespace:
+                  type: string
+                currentInstallationParams:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                acpVersion:
+                  type: string
       subresources:
         status: {}
   names:


### PR DESCRIPTION
## Summary

- replace the top-level preserve-unknown schemas for TridentOrchestrator and TridentConfigurator with structural OpenAPI schemas
- update the runtime embedded CRD YAML used by the operator installer
- keep static deploy and Helm CRD copies in sync
- update CRD YAML tests to assert the new schema shape

## Notes

This is intentionally opened as a draft. It starts with the operator CRDs because they are the public install/configuration entry points and currently accept arbitrary top-level fields.

TridentConfigurator.spec remains a raw object with x-kubernetes-preserve-unknown-fields because the Go API type is runtime.RawExtension and backend configurator payloads are storage-driver-specific. The root CRD and status are now structural.

TridentOrchestrator.status.currentInstallationParams is also left preserve-unknown for this draft because it is an operator-produced status snapshot and contains nested install state that should be tightened separately if desired.

This branch is based on current master and does not include the sidecar image fields from #1156. If #1156 is accepted first, this schema PR should be rebased and extended with those new fields.

## Validation

- go test ./cli/k8s_client -run 'TestGet(Configurator|Orchestrator)CRDYAML' -count=1
- go test ./cli/k8s_client -run 'TestGetCRDsYAML/tridentconfigurators.trident.netapp.io' -count=1
- ruby YAML parse for all updated static CRD files
- kubectl create --dry-run=client --validate=false for all updated static CRD files
- helm lint ./helm/trident-operator
- git diff --check