### PR TITLE
Rescan NVMe namespaces when a published namespace device is missing

### DIFF
--- a/utils/nvme/nvme.go
+++ b/utils/nvme/nvme.go
@@ -300,6 +300,17 @@ func (nh *NVMeHandler) AttachNVMeVolume(
 
 	nvmeDev, err := nvmeSubsys.GetNVMeDevice(ctx, publishInfo.NVMeNamespaceUUID)
 	if err != nil {
+		// Subsystem is connected but the namespace device is absent, likely a missed namespace
+		// notification. Trigger a rescan so a subsequent attach retry can find the device.
+		if connectionStatus == NVMeSubsystemConnected && errors.IsNotFoundError(err) {
+			if rescanErr := nvmeSubsys.RescanNamespaces(ctx); rescanErr != nil {
+				Logc(ctx).WithError(rescanErr).Warning(
+					"Failed to rescan NVMe namespaces after namespace device was not found.")
+			} else {
+				Logc(ctx).WithField("namespace", publishInfo.NVMeNamespaceUUID).Debug(
+					"Triggered NVMe namespace rescan after namespace device was not found.")
+			}
+		}
 		return err
 	}
 	devPath := nvmeDev.GetPath()
@@ -679,6 +690,14 @@ func (nh *NVMeHandler) InspectNVMeSessions(
 			pubSessionData.SetRemediation(ConnectOp)
 			subsToFix = append(subsToFix, currSessionData.Subsystem)
 			continue
+		case NVMeSubsystemConnected:
+			// All paths are up but a published namespace may still be missing its device after a
+			// missed namespace notification. Schedule a rescan to recover it.
+			if nh.subsystemHasMissingNamespace(ctx, &currSessionData.Subsystem, pubSessionData) {
+				pubSessionData.SetRemediation(RescanOp)
+				subsToFix = append(subsToFix, currSessionData.Subsystem)
+				continue
+			}
 		}
 
 		// All/None of the paths are present for the subsystem
@@ -687,6 +706,39 @@ func (nh *NVMeHandler) InspectNVMeSessions(
 
 	SortSubsystemsUsingSessions(subsToFix, pubSessions)
 	return subsToFix
+}
+
+// subsystemHasMissingNamespace reports whether any namespace published on the subsystem is missing
+// its device on the host, a condition a namespace rescan can recover.
+func (nh *NVMeHandler) subsystemHasMissingNamespace(
+	ctx context.Context, sub *NVMeSubsystem, sessionData *NVMeSessionData,
+) bool {
+	if sessionData == nil {
+		return false
+	}
+
+	if present, err := afero.DirExists(sub.osFs, sub.Name); err != nil || !present {
+		return false
+	}
+
+	for nsUUID := range sessionData.Namespaces {
+		_, err := sub.GetNVMeDeviceAt(ctx, nsUUID)
+		if err == nil {
+			continue
+		}
+		if errors.IsNotFoundError(err) {
+			Logc(ctx).WithFields(LogFields{
+				"subsystem": sub.NQN,
+				"namespace": nsUUID,
+			}).Warning("Published NVMe namespace has no device on host; scheduling namespace rescan.")
+			return true
+		}
+
+		Logc(ctx).WithError(err).WithField("namespace", nsUUID).Debug(
+			"Error while checking NVMe namespace device presence during self-healing.")
+	}
+
+	return false
 }
 
 // RectifyNVMeSession applies the required remediation on the subsystemToFix to make it working again.
@@ -705,11 +757,19 @@ func (nh *NVMeHandler) RectifyNVMeSession(
 	// Updating the access time as we are trying to do some NVMeOperation on this subsystem.
 	pubSessionData.LastAccessTime = time.Now()
 
-	if pubSessionData.Remediation == ConnectOp {
+	switch pubSessionData.Remediation {
+	case ConnectOp:
 		if err := subsystemToFix.Connect(ctx, pubSessionData.NVMeTargetIPs, true); err != nil {
 			Logc(ctx).Errorf("NVMe Self healing failed for subsystem %s; %v", subsystemToFix.NQN, err)
 		} else {
 			Logc(ctx).Infof("NVMe Self healing succeeded for %s", subsystemToFix.NQN)
+		}
+	case RescanOp:
+		if err := subsystemToFix.RescanNamespaces(ctx); err != nil {
+			Logc(ctx).Errorf("NVMe Self healing (namespace rescan) failed for subsystem %s; %v",
+				subsystemToFix.NQN, err)
+		} else {
+			Logc(ctx).Infof("NVMe Self healing (namespace rescan) succeeded for %s", subsystemToFix.NQN)
 		}
 	}
 }

--- a/utils/nvme/nvme_darwin.go
+++ b/utils/nvme/nvme_darwin.go
@@ -46,6 +46,13 @@ func (s *NVMeSubsystem) DisconnectSubsystemFromHost(ctx context.Context) error {
 	return errors.UnsupportedError("DisconnectSubsystemFromHost is not supported for darwin")
 }
 
+// RescanNamespaces re-enumerates the namespaces on the subsystem's controllers.
+func (s *NVMeSubsystem) RescanNamespaces(ctx context.Context) error {
+	Logc(ctx).Debug(">>>> nvme_darwin.RescanNamespaces")
+	defer Logc(ctx).Debug("<<<< nvme_darwin.RescanNamespaces")
+	return errors.UnsupportedError("RescanNamespaces is not supported for darwin")
+}
+
 func (nh *NVMeHandler) GetNVMeSubsystem(ctx context.Context, nqn string) (*NVMeSubsystem,
 	error,
 ) {

--- a/utils/nvme/nvme_linux.go
+++ b/utils/nvme/nvme_linux.go
@@ -351,6 +351,37 @@ func (s *NVMeSubsystem) GetNVMeDeviceAt(ctx context.Context, nsUUID string) (*NV
 	return nil, errors.NotFoundError("no device found for the given namespace %v", nsUUID)
 }
 
+// RescanNamespaces re-enumerates the namespaces on each of the subsystem's controllers using
+// "nvme ns-rescan". It recovers namespaces that are mapped but missing on the host; it only adds
+// namespaces and never renames existing devices, so it is safe on a connected subsystem.
+func (s *NVMeSubsystem) RescanNamespaces(ctx context.Context) error {
+	Logc(ctx).Debug(">>>> nvme_linux.RescanNamespaces")
+	defer Logc(ctx).Debug("<<<< nvme_linux.RescanNamespaces")
+
+	if len(s.Paths) == 0 {
+		return fmt.Errorf("no paths present for subsystem %s; cannot rescan namespaces", s.NQN)
+	}
+
+	failed := 0
+	for _, path := range s.Paths {
+		// path.Name is the controller's sysfs path, e.g. .../nvme0; the device is /dev/nvme0.
+		controller := "/dev/" + path.Name[strings.LastIndex(path.Name, "/")+1:]
+		if _, err := s.command.Execute(ctx, "nvme", "ns-rescan", controller); err != nil {
+			Logc(ctx).WithError(err).Errorf("Failed to rescan namespaces on controller %s.", controller)
+			failed++
+			continue
+		}
+		Logc(ctx).WithField("controller", controller).Debug("Rescanned NVMe namespaces on controller.")
+	}
+
+	// Succeed if at least one controller path was rescanned successfully.
+	if failed == len(s.Paths) {
+		return fmt.Errorf("failed to rescan namespaces on all paths for subsystem %s", s.NQN)
+	}
+
+	return nil
+}
+
 // FlushNVMeDevice flushes any ongoing IOs present on the NVMe device.
 func (d *NVMeDevice) FlushNVMeDevice(ctx context.Context) error {
 	Logc(ctx).Debug(">>>> nvme_linux.FlushNVMeDevice")

--- a/utils/nvme/nvme_types.go
+++ b/utils/nvme/nvme_types.go
@@ -113,6 +113,7 @@ type NVMeOperation int8
 const (
 	NoOp NVMeOperation = iota
 	ConnectOp
+	RescanOp
 )
 
 // NVMeSessionData contains all the information related to any NVMe session. It has the subsystem information, the
@@ -136,6 +137,7 @@ type NVMeSessions struct {
 type NVMeSubsystemInterface interface {
 	GetConnectionStatus() NVMeSubsystemConnectionStatus
 	Connect(ctx context.Context, nvmeTargetIps []string, connectOnly bool) error
+	RescanNamespaces(ctx context.Context) error
 	Disconnect(ctx context.Context) error
 	GetNamespaceCount(ctx context.Context) (int, error)
 	IsNetworkPathPresent(ip string) bool

--- a/utils/nvme/nvme_windows.go
+++ b/utils/nvme/nvme_windows.go
@@ -46,6 +46,13 @@ func (s *NVMeSubsystem) DisconnectSubsystemFromHost(ctx context.Context) error {
 	return errors.UnsupportedError("DisconnectSubsystemFromHost is not supported for windows")
 }
 
+// RescanNamespaces re-enumerates the namespaces on the subsystem's controllers.
+func (s *NVMeSubsystem) RescanNamespaces(ctx context.Context) error {
+	Logc(ctx).Debug(">>>> nvme_windows.RescanNamespaces")
+	defer Logc(ctx).Debug("<<<< nvme_windows.RescanNamespaces")
+	return errors.UnsupportedError("RescanNamespaces is not supported for windows")
+}
+
 func (nh *NVMeHandler) GetNVMeSubsystem(ctx context.Context, nqn string) (*NVMeSubsystem, error) {
 	Logc(ctx).Debug(">>>> nvme_windows.GetNVMeSubsystem")
 	defer Logc(ctx).Debug("<<<< nvme_windows.GetNVMeSubsystem")


### PR DESCRIPTION
## Change description

Rescan NVMe namespaces when a published namespace device is missing

When a namespace is mapped to an already-connected NVMe subsystem, the
host only creates its device node in response to an asynchronous
notification from the controller. If that notification is missed, the
device never appears and NodeStageVolume keeps failing with "no device
found for the given namespace".

Recover the namespace by issuing "nvme ns-rescan" on the subsystem's
controllers: from the AttachNVMeVolume retry loop when the device is
missing on an already-connected subsystem, and from NVMe self-healing
when a published namespace has no device on the host. The self-healing
case mirrors iSCSI self-healing, which already rescans the host for
devices. A rescan only adds missing namespaces and never renames
existing devices, so it is safe on a connected subsystem.

## Project tracking

- [x] This PR does not require a JIRA ticket (explain below why)

External community contribution. [NetApp KB "Unable to mount PVC due to Kubernetes namespace error"](https://kb.netapp.com/Cloud/Astra/Trident/Unable_to_mount_PVC_due_to_Kubernetes_namespace_error) documents this exact error but blames a missing namespace. The error fires during node staging, after the controller Publish has already mapped the namespace on ONTAP, so the namespace exists; the host just never enumerated it (nvme ns-rescan recovers it). This PR fixes that cause.

## Do any added TODOs have an issue in the backlog?

None added.

## Did you add unit tests? Why not?

The behavior that matters, whether the host re-enumerates the namespace after the rescan, is host/kernel behavior a unit test can't reproduce; a test could only assert that nvme ns-rescan is issued, not that the device returns. That recovery is covered by functional testing. Existing utils/nvme tests pass.

## Does this code need functional testing?

Yes. This is host-level NVMe/TCP behavior unit tests can't fully cover. Best validated on NVMe/TCP with raw-block volumes by reproducing the hang under concurrent VM clones. Already confirmed manually that nvme ns-rescan recovers the stuck namespace on the affected node.

## Is a code review walkthrough needed? why or why not?

A short one would help. The root cause (a missed NVMe discovery notification on an already-connected, namespace-dense subsystem) is non-obvious, and the change adds a new host command and a self-healing remediation.

## Should additional test coverage be executed in addition to pre-merge?

NVMe/TCP with raw-block volumes (many namespaces in one subsystem) under concurrent volume creation/clone, plus a check that NodeStage and NodeUnstage are otherwise unaffected.

## Does this code need a note in the changelog?

Yes:

> Fixed an issue where an NVMe/TCP namespace could fail to stage with "no device found for the given namespace" on an already-connected subsystem when the host missed the namespace discovery notification; Trident now rescans the subsystem to recover the namespace.

## Does this code require documentation changes?

No. Internal recovery mechanism, no config, CRD, or API change.

## Additional Information

Under concurrent VM clones on NVMe/TCP, PVCs intermittently hang in NodeStageVolume with "no device found for the given namespace" while sibling volumes on the same subsystem mount fine. For raw-block volumes Trident packs many namespaces into one shared subsystem (getSuperSubsystemName, up to 1024), so after the first volume connects it, discovery of each later namespace depends on that one controller's notifications, and a clone burst makes a missed one likely. Trident's only recovery was a 20s retry that re-reads stale sysfs, with no rescan fallback. The self-healing addition mirrors iSCSI self-healing, which already rescans the host for LUNs (scanForAllLUNs).

This is the error from [NetApp KB "Unable to mount PVC due to Kubernetes namespace error"](https://kb.netapp.com/Cloud/Astra/Trident/Unable_to_mount_PVC_due_to_Kubernetes_namespace_error), which blames a missing namespace and says to recreate the PVC. That cause is wrong here: the error fires after Publish has already mapped the namespace on ONTAP, so it exists, and nvme ns-rescan recovers it (impossible if it didn't exist). Recreating the PVC only works by forcing re-enumeration, at the cost of destroying the PVC's data (e.g. a KubeVirt VM disk). This PR rescans to recover the namespace directly; if one is genuinely absent the rescan is a harmless no-op and the existing error still surfaces.

Builds for linux and darwin, go vet clean, existing utils/nvme tests pass.