### PR TITLE
Fix CSI controller URL for IPv6 service hosts

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -348,7 +349,7 @@ func controllerRestURL() string {
 	if hostname == "" {
 		hostname = config.ServerCertName
 	}
-	return "https://" + hostname + ":" + port
+	return "https://" + net.JoinHostPort(hostname, port)
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,46 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestControllerRestURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		host     string
+		port     string
+		expected string
+	}{
+		{
+			name:     "IPv6 address",
+			host:     "2001:db8::1",
+			port:     "34571",
+			expected: "https://[2001:db8::1]:34571",
+		},
+		{
+			name:     "IPv4 address",
+			host:     "192.0.2.10",
+			port:     "34571",
+			expected: "https://192.0.2.10:34571",
+		},
+		{
+			name:     "DNS name",
+			host:     "trident-csi",
+			port:     "34571",
+			expected: "https://trident-csi:34571",
+		},
+		{
+			name:     "defaults",
+			expected: "https://trident-csi:34571",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TRIDENT_CSI_SERVICE_HOST", tc.host)
+			t.Setenv("TRIDENT_CSI_SERVICE_PORT", tc.port)
+			assert.Equal(t, tc.expected, controllerRestURL())
+		})
+	}
+}
+
 func TestMain_processCommandLineArgs_QPS(t *testing.T) {
 	type parameters struct {
 		k8sApiQPS         float64


### PR DESCRIPTION
## Change description
Fix CSI node registration when `TRIDENT_CSI_SERVICE_HOST` contains an IPv6 literal.

The node plugin used string concatenation to build the controller REST endpoint as `https://<host>:<port>`. With an IPv6 service host such as `2001:db8::10`, that produced an invalid URL like `https://2001:db8::10:34571`, causing Go URL parsing to fail before `CreateNode` could register the node with the CSI controller.

This change builds the host/port portion with `net.JoinHostPort`, producing `https://[2001:db8::10]:34571` for IPv6 while preserving existing IPv4 and DNS-name behavior.

Fixes #1164

## Project tracking
- [x] This PR does not require a JIRA ticket (explain below why)

External community bug fix tracked by GitHub issue #1164.

## Do any added TODOs have an issue in the backlog?
No TODOs added.

## Did you add unit tests? Why not?
Yes. Added `TestControllerRestURL` covering IPv6, IPv4, and DNS host inputs.

## Does this code need functional testing?
No dedicated functional test is required for this small URL-construction fix. The unit test covers the bug condition directly.

## Is a code review walkthrough needed? why or why not?
No. The change is limited to constructing the controller REST URL with `net.JoinHostPort` and adding focused unit coverage.

## Should additional test coverage be executed in addition to pre-merge?
No additional coverage beyond existing pre-merge testing is expected.

## Does this code need a note in the changelog?
`/needs-changelog`

This affects CSI node readiness on IPv6-only Kubernetes clusters when service-link environment variables are present.

## Changelog
Fixed CSI node registration when the controller service host is provided as an IPv6 literal by Kubernetes service-link environment variables.

## Does this code require documentation changes?
No. This is an internal URL-construction bug fix with no user-facing configuration changes.

## Additional Information
Affected released tags checked locally: `v26.02.1` and `v26.06.0` both contain the unbracketed controller URL construction. Current `master` also contained it before this change.

Validation performed:

```text
gofmt -w frontend/csi/plugin.go frontend/csi/plugin_test.go
go test ./frontend/csi
```
