### PR TITLE
Copy StorageClass and AccessMode to cloneConfig on volume cloning

### DIFF
--- a/core/orchestrator_core.go
+++ b/core/orchestrator_core.go
@@ -2663,6 +2663,12 @@ func (o *TridentOrchestrator) cloneVolumeInitial(
 		cloneConfig.SMBShareACL = volumeConfig.SMBShareACL
 	}
 	cloneConfig.ReadOnlyClone = volumeConfig.ReadOnlyClone
+	if volumeConfig.StorageClass != "" {
+		cloneConfig.StorageClass = volumeConfig.StorageClass
+	}
+	if volumeConfig.AccessMode != "" {
+		cloneConfig.AccessMode = volumeConfig.AccessMode
+	}
 	cloneConfig.Namespace = volumeConfig.Namespace
 	cloneConfig.RequestName = volumeConfig.RequestName
 

--- a/core/orchestrator_core_test.go
+++ b/core/orchestrator_core_test.go
@@ -1343,6 +1343,63 @@ func TestCloneVolume_VolumeDataSource_LUKS(t *testing.T) {
 	defer orchestrator.DeleteVolume(ctx(), cloneResult.Config.Name)
 }
 
+func TestCloneVolume_CrossStorageClassAndAccessMode(t *testing.T) {
+	// Setup
+	mockPools := tu.GetFakePools()
+	orchestrator := getOrchestrator(t, false)
+
+	// Create backend
+	poolNames := []string{tu.SlowSnapshots}
+	pools := make(map[string]*fake.StoragePool, len(poolNames))
+	for _, poolName := range poolNames {
+		pools[poolName] = mockPools[poolName]
+	}
+	volumes := make([]fake.Volume, 0)
+	cfg, err := fakedriver.NewFakeStorageDriverConfigJSON("slow-block", "block", pools, volumes)
+	assert.NoError(t, err)
+	_, err = orchestrator.AddBackend(ctx(), cfg, "")
+	assert.NoError(t, err)
+	defer orchestrator.DeleteBackend(ctx(), "slow-block")
+
+	// Create StorageClass 'sc-rwo'
+	storageClassRWO := &storageclass.Config{Name: "sc-rwo"}
+	_, err = orchestrator.AddStorageClass(ctx(), storageClassRWO)
+	defer orchestrator.DeleteStorageClass(ctx(), storageClassRWO.Name)
+	assert.NoError(t, err)
+
+	// Create StorageClass 'sc-rwx'
+	storageClassRWX := &storageclass.Config{Name: "sc-rwx"}
+	_, err = orchestrator.AddStorageClass(ctx(), storageClassRWX)
+	defer orchestrator.DeleteStorageClass(ctx(), storageClassRWX.Name)
+	assert.NoError(t, err)
+
+	// Create the Source Volume using 'sc-rwo' and ReadWriteOnce
+	volConfig := tu.GenerateVolumeConfig("block", 1, "sc-rwo", config.Block)
+	volConfig.AccessMode = config.ReadWriteOnce
+	_, err = orchestrator.AddVolume(ctx(), volConfig)
+	assert.NoError(t, err)
+	defer orchestrator.DeleteVolume(ctx(), volConfig.Name)
+
+	// Now clone the volume into 'sc-rwx' and ReadWriteMany
+	cloneName := volConfig.Name + "_clone"
+	cloneConfig := &storage.VolumeConfig{
+		Name:              cloneName,
+		StorageClass:      "sc-rwx",
+		AccessMode:        config.ReadWriteMany,
+		CloneSourceVolume: volConfig.Name,
+		VolumeMode:        volConfig.VolumeMode,
+	}
+	cloneResult, err := orchestrator.CloneVolume(ctx(), cloneConfig)
+	assert.NoError(t, err)
+	defer orchestrator.DeleteVolume(ctx(), cloneResult.Config.Name)
+
+	// Verify that the clone has the requested StorageClass and AccessMode,
+	// rather than inheriting the source volume's configuration.
+	assert.Equal(t, "sc-rwx", cloneResult.Config.StorageClass)
+	assert.Equal(t, config.ReadWriteMany, cloneResult.Config.AccessMode)
+}
+
+
 func TestCloneVolume_WithImportNotManaged(t *testing.T) {
 	orchestrator := getOrchestrator(t, false)
 	defer cleanup(t, orchestrator)


### PR DESCRIPTION
## Change description
<!-- This should be the resulting commit message when the PR is merged. --> 

Copy StorageClass and AccessMode to cloneConfig on volume cloning

Ensure that during volume cloning, target StorageClass and AccessMode from volumeConfig are copied onto cloneConfig if they are specified, so that the metadata in the TridentVolume CR remains in sync with the Kubernetes PV state.

Fixes Issue #1162

## Project tracking
<!-- Required: Provide the Jira Issue key or URL below. Use the override checkbox if not applicable. -->


- [ x] This PR does not require a JIRA ticket (explain below why)
<!-- If checked, you MUST provide an explanation below or the PR will be blocked. -->

This is an upstream open-source contribution to the NetApp Trident repository and does not track against internal JIRA.

## Do any added TODOs have an issue in the backlog?
<!-- Enumerate them on the lines below. -->

No.

## Did you add unit tests? Why not?

Yes, added `TestCloneVolume_CrossStorageClassAndAccessMode` in `core/orchestrator_core_test.go` to assert that both `StorageClass` and `AccessMode` are correctly inherited by the clone configuration when cloning a volume.

## Does this code need functional testing?
<!-- If yes, @ the person who should write the test on the following line. Otherwise, provide an explanation why it doesn't. -->

No. The logic is fully validated by the added unit tests in the orchestrator core.

## Is a code review walkthrough needed? why or why not?

No. The change is simple and localized, only copying two string fields from `volumeConfig` onto `cloneConfig` during the clone configuration build stage.

## Should additional test coverage be executed in addition to pre-merge?
<!-- If yes, enumerate the configurations/coverage below and update when passing. -->

No.

## Does this code need a note in the changelog?
<!-- Comment `/needs-changelog` or `/no-changelog` on this PR (author or collaborator). Maintainers may also set those labels in the GitHub UI. -->
<!-- If `/needs-changelog`, add a release-note entry under `## Changelog` below. If `/no-changelog`, add a brief explanation there of why no release note is needed. Merge requires exactly one label — not changelog text in the description. -->


## Changelog
<!-- Release note text for user-facing changes, or rationale when using no-changelog. -->

Fixed volume cloning to ensure the clone inherits the target `StorageClass` and `AccessMode` when specified.

## Does this code require documentation changes?
<!-- If yes, please indicate it. Otherwise, provide an explanation why it doesn't. -->

No. This fixes a bug where metadata became out-of-sync; the expected behavior remains the same.

## Additional Information

