### PR TITLE
fix(nvme): detect built-in tcp transport

### DIFF
--- a/utils/nvme/nvme_linux.go
+++ b/utils/nvme/nvme_linux.go
@@ -29,8 +29,9 @@ var (
 )
 
 const (
-	NVME_PATH = "/sys/class/nvme-subsystem"
-	SUBSYSNQN = "/subsysnqn"
+	NVME_PATH                = "/sys/class/nvme-subsystem"
+	NVME_TCP_SYS_MODULE_PATH = "/sys/module/nvme_tcp"
+	SUBSYSNQN                = "/subsysnqn"
 )
 
 // GetHostNqn returns the Nqn string of the k8s node.
@@ -57,6 +58,15 @@ func (nh *NVMeHandler) NVMeActiveOnHost(ctx context.Context) (bool, error) {
 	if err != nil {
 		Logc(ctx).WithError(err).Warn("Could not read NVMe CLI version; perhaps NVMe CLI is not installed?")
 		return false, fmt.Errorf("failed to get hostnqn: %v", err)
+	}
+
+	// Loaded and built-in kernel modules are both exposed through sysfs. Checking
+	// sysfs allows NVMe/TCP to be detected on hosts that compile it into the kernel.
+	nvmeTCPModuleExists, err := afero.DirExists(nh.osFs, NVME_TCP_SYS_MODULE_PATH)
+	if err != nil {
+		Logc(ctx).WithError(err).Warn("Could not inspect the NVMe/TCP kernel module in sysfs.")
+	} else if nvmeTCPModuleExists {
+		return true, nil
 	}
 
 	out, err := nh.command.ExecuteWithTimeout(ctx, "lsmod", NVMeListCmdTimeoutInSeconds*time.Second, false)

--- a/utils/nvme/nvme_linux_test.go
+++ b/utils/nvme/nvme_linux_test.go
@@ -61,18 +61,31 @@ func TestNVMeActiveOnHost(t *testing.T) {
 	ctx := context.Background()
 	mockCtrl := gomock.NewController(t)
 	mockCommand := mockexec.NewMockCommand(mockCtrl)
+	osFs := afero.NewMemMapFs()
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "nvme", NVMeListCmdTimeoutInSeconds*time.Second,
 		false, "version").Return([]byte(""), nil)
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "lsmod", NVMeListCmdTimeoutInSeconds*time.Second,
 		false).Return([]byte("nvme_tcp"), nil)
 
-	handler := NewNVMeHandlerDetailed(mockCommand, nil, nil, nil, nil)
+	handler := NewNVMeHandlerDetailed(mockCommand, nil, nil, nil, osFs)
 	gotValue, err := handler.NVMeActiveOnHost(ctx)
 
 	assert.Equal(t, expectedValue, gotValue)
 	assert.NoError(t, err)
 
-	// Test2: Error - NVMe cli is not installed on host
+	// Test2: Success - NVMe/TCP is built into the host kernel
+	builtInModuleFs := afero.NewMemMapFs()
+	assert.NoError(t, builtInModuleFs.MkdirAll(NVME_TCP_SYS_MODULE_PATH, 0o755))
+	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "nvme", NVMeListCmdTimeoutInSeconds*time.Second,
+		false, "version").Return([]byte(""), nil)
+
+	handler = NewNVMeHandlerDetailed(mockCommand, nil, nil, nil, builtInModuleFs)
+	gotValue, err = handler.NVMeActiveOnHost(ctx)
+
+	assert.Equal(t, expectedValue, gotValue)
+	assert.NoError(t, err)
+
+	// Test3: Error - NVMe cli is not installed on host
 	expectedValue = false
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "nvme", NVMeListCmdTimeoutInSeconds*time.Second,
 		false, "version").Return([]byte(""), errors.New("NVMe CLI not installed"))
@@ -82,8 +95,9 @@ func TestNVMeActiveOnHost(t *testing.T) {
 	assert.Equal(t, expectedValue, gotValue)
 	assert.Error(t, err)
 
-	// Test3: Error - Unable to get driver info
+	// Test4: Error - Unable to get driver info
 	expectedValue = false
+	handler = NewNVMeHandlerDetailed(mockCommand, nil, nil, nil, osFs)
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "nvme", NVMeListCmdTimeoutInSeconds*time.Second,
 		false, "version").Return([]byte(""), nil)
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "lsmod", NVMeListCmdTimeoutInSeconds*time.Second,
@@ -94,7 +108,7 @@ func TestNVMeActiveOnHost(t *testing.T) {
 	assert.Equal(t, expectedValue, gotValue)
 	assert.Error(t, err)
 
-	// Test4: Error - NVMe/tcp module not loaded on the host
+	// Test5: Error - NVMe/TCP is neither loaded nor built into the host kernel
 	expectedValue = false
 	mockCommand.EXPECT().ExecuteWithTimeout(ctx, "nvme", NVMeListCmdTimeoutInSeconds*time.Second,
 		false, "version").Return([]byte(""), nil)


### PR DESCRIPTION
## Change description

Detect NVMe/TCP support through `/sys/module/nvme_tcp` before falling back to `lsmod`. Sysfs exposes both loaded and built-in kernel modules, allowing Trident to register NVMe/TCP support on hosts such as Talos that compile the transport into the kernel.

Fixes #1019

## Project tracking

https://github.com/NetApp/trident/issues/1019

- [x] This PR does not require a JIRA ticket (explain below why)

This external contribution fixes the linked GitHub bug report.

## Do any added TODOs have an issue in the backlog?

No TODOs were added.

## Did you add unit tests? Why not?

Yes. The regression test creates the NVMe/TCP sysfs module directory and verifies the host is reported active without consulting `lsmod`.

## Does this code need functional testing?

No dedicated functional test is required for the capability check. The focused unit test covers the built-in-kernel path; validation on a Talos NVMe/TCP node may be performed if that environment is available.

## Is a code review walkthrough needed? why or why not?

No. The change is localized to NVMe/TCP host capability detection and its unit test.

## Should additional test coverage be executed in addition to pre-merge?

No additional coverage is required.

## Does this code need a note in the changelog?

Yes. Please apply the `needs-changelog` label.

## Changelog

Fixed NVMe/TCP host detection when the transport is compiled into the kernel instead of loaded as a module.

## Does this code require documentation changes?

No. This corrects runtime capability detection without changing user-facing configuration.

## Additional Information

The existing `lsmod` check remains as a fallback when the sysfs module directory is unavailable.
